### PR TITLE
Payload optional in the director workflow run command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each workflow can be manually executed in different ways.
 **Using the CLI**
 
 ```
-$ director workflow run ovh.SIMPLE_ETL '{}'
+$ director workflow run ovh.SIMPLE_ETL
 ```
 
 **Using the API**

--- a/director/commands/workflows.py
+++ b/director/commands/workflows.py
@@ -89,7 +89,7 @@ def show_workflow(ctx, name):
 
 @workflow.command(name="run")
 @click.argument("fullname")
-@click.argument("payload")
+@click.argument("payload", required=False, default="{}")
 @pass_ctx
 def run_workflow(ctx, fullname, payload):
     """Execute a workflow"""
@@ -98,10 +98,10 @@ def run_workflow(ctx, fullname, payload):
         payload = json.loads(payload)
     except WorkflowNotFound as e:
         click.echo(f"Error: {e}")
-        return
+        raise click.Abort()
     except JSONDecodeError as e:
         click.echo(f"Error parsing the JSON payload : {e}")
-        return
+        raise click.Abort()
 
     # Create the workflow object
     project, name = fullname.split(".")
@@ -109,5 +109,5 @@ def run_workflow(ctx, fullname, payload):
     obj.save()
 
     # Build the canvas and execute it
-    workflow = WorkflowBuilder(obj.id)
-    workflow.run()
+    _workflow = WorkflowBuilder(obj.id)
+    _workflow.run()


### PR DESCRIPTION
- The mininmal command to run a workflow is now: `director workflow run ovh.SIMPLE_ETL`
- If errors are occuring during payload parsing or not found workflows do not return zero
