### PR TITLE
feat(docker): add docker-compose capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+ARG DIRECTOR_HOME
+ENV DIRECTOR_HOME=${DIRECTOR_HOME:-/app/workflows/}
+COPY director/ /app/director/
+COPY setup.py /app/
+COPY requirements.txt /app/
+COPY entrypoint.sh /
+WORKDIR /app
+RUN python setup.py install
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["webserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '3.4'
+
+x-director: &app_base
+  image: director
+  build:
+    context: .
+  environment:
+    - DOCKER_DIRECTOR_BROKER_URI=redis://redis:6379/0
+    - DOCKER_DIRECTOR_RESULT_BACKEND_URI=redis://redis:6379/1
+    - DOCKER_DIRECTOR_CELERY_ONCE_URI=redis://redis:6379/2
+    - DOCKER_DIRECTOR_REDIS_BACKEND_URI=redis://redis:6379/3
+    - DOCKER_DIRECTOR_API_URL=http://127.0.0.1:5000/api
+    - DOCKER_DIRECTOR_DATABASE_URI=postgresql://${POSTGRES_USER:-director}:${POSTGRES_PASSWORD:-director}@db:5432/${POSTGRES_DB:-director}
+    - DOCKER_DIRECTOR_FLOWER_URL=http://flower:5555
+    - DIRECTOR_ENABLE_DARK_THEME=false
+    - DIRECTOR_DATABASE_POOL_RECYCLE=120
+    - DIRECTOR_HOME=/app/workflows
+    #- DIRECTOR_GIT_WORKFLOWS=https://github.com/your/repo.git
+  networks:
+    - director
+  depends_on:
+    - db
+    - redis
+
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-director}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-director}
+      - POSTGRES_DB=${POSTGRES_DB:-director}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - director
+
+  redis:
+    image: redis
+    networks:
+      - director
+
+  web:
+    <<: *app_base
+    ports:
+      - 8000:8000
+      - 5000:5000
+    command: webserver -b 0.0.0.0
+    volumes:
+      - ./director_home/:/app/workflows
+
+  worker:
+    <<: *app_base
+    command: celery worker
+    volumes:
+      - ./director_home/:/app/workflows
+
+  beat:
+    <<: *app_base
+    command: celery beat
+
+  flower:
+    <<: *app_base
+    command: celery flower
+
+networks:
+  director:
+    external: false
+    attachable: true
+
+volumes:
+  director:
+    external: false
+  postgres_data:
+    external: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+DIRECTOR_HOME=${DIRECTOR_HOME:-/app/workflows}
+DIRECTOR_GIT_WORKFLOWS=${DIRECTOR_GIT_WORKFLOWS:-}
+OVERIDE_DIRECTOR_ENV=${OVERIDE_DIRECTOR_ENV:-true}
+export DIRECTOR_HOME
+
+# init from a git repository if DIRECTOR_GIT_WORKFLOWS is set
+if [[ ! -d "$DIRECTOR_HOME/tasks" && ! -f "$DIRECTOR_HOME/workflows.yml" ]]; then
+  echo "Project not initialized !"
+  if [ ! $DIRECTOR_GIT_WORKFLOWS == '' ]; then
+    echo "Project initilization from git"
+    mkdir -p $DIRECTOR_HOME
+    echo "cloning $DIRECTOR_GIT_WORKFLOWS to $DIRECTOR_HOME"
+    git clone $DIRECTOR_GIT_WORKFLOWS $DIRECTOR_HOME
+  else
+    echo "Project initialization"
+    director init "$DIRECTOR_HOME"
+  fi
+else
+  echo "Project already initialized"
+fi
+if [ -f "$DIRECTOR_HOME/requirements.txt" ]; then
+  pip install -r $DIRECTOR_HOME/requirements.txt || echo ""
+fi
+
+# Overide some DIRECTOR_ENV if declared as DOCKER_DIRECTOR
+if [ "$OVERIDE_DIRECTOR_ENV" = true ]; then
+  source $DIRECTOR_HOME/.env || echo ""
+  export $(printenv | grep ^DOCKER_DIRECTOR | sed -e "s/^DOCKER_DIRECTOR/DIRECTOR/g")
+  printenv | grep ^DIRECTOR > $DIRECTOR_HOME/.env
+fi
+
+echo "Starting Director"
+director "$@"


### PR DESCRIPTION
1. Allow to have a working environment from running 2 commands
- docker-compose build
- docker-compose run
2. Allow to checkout workflows from a separated git repository by adding DIRECTOR_GIT_WORKFLOWS=(your repo) as an environment variable