### PR TITLE
chore(github): add default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers
+*       @ncrocfer @anthonyolea @ziirish @maximecaruchet


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@corp.ovh.com>