### PR TITLE
Add new variable for the .env file

### DIFF
--- a/director/_auto.py
+++ b/director/_auto.py
@@ -1,7 +1,6 @@
 # initialize a working context
-import os
 
 from director import create_app
 from director.extensions import cel
 
-app = create_app(os.getenv("DIRECTOR_HOME"))
+app = create_app()

--- a/director/context.py
+++ b/director/context.py
@@ -7,7 +7,7 @@ from director import create_app
 
 class DirectorContext(click.Context):
     def __init__(self):
-        self.app = create_app(os.getenv("DIRECTOR_HOME"))
+        self.app = create_app()
         self.app.app_context().push()
 
 

--- a/director/settings.py
+++ b/director/settings.py
@@ -16,12 +16,20 @@ HIDDEN_CONFIG = [
 
 
 class Config(object):
-    def __init__(self, path):
-        self.DIRECTOR_HOME = path
+    def __init__(self, home_path=None, config_path=None):
+        if not home_path or not Path(home_path).resolve().exists():
+            raise ValueError("environment variable DIRECTOR_HOME is not set correctly")
+        self.DIRECTOR_HOME = env_path = str(home_path)
 
-    def init_vars(self):
+        if config_path:
+            if not Path(config_path).resolve().exists():
+                raise ValueError(
+                    "environment variable DIRECTOR_CONFIG is not set correctly"
+                )
+            env_path = config_path
+
         env = Env()
-        env.read_env(str(Path(self.DIRECTOR_HOME).resolve() / ".env"))
+        env.read_env(env_path)
 
         self.ENABLE_DARK_THEME = env.bool("DIRECTOR_ENABLE_DARK_THEME", False)
         self.ENABLE_CDN = env.bool("DIRECTOR_ENABLE_CDN", True)


### PR DESCRIPTION
- Add: environement variable `DIRECTOR_CONFIG` (optional), export this variable if you want to specified your very own `.env`file (e.g.: `export DIRECTOR_CONFIG=/home/foobar/workflows/director.env`).
- Add: when `DIRECTOR_HOME` is not set, Director will raise a `ValueError` with a more explicit message (compared to the default message)
- Fixed: `DIRECTOR` prefixed environment variables are properly used if you do not want to use `.env `file.