### PR TITLE
fix(cli): do not use the flower url from the dotenv file

### DIFF
--- a/director/commands/celery.py
+++ b/director/commands/celery.py
@@ -57,15 +57,5 @@ def worker(dev_mode, worker_args):
 def flower(ctx, flower_args):
     """Start the flower instance"""
     broker = ctx.app.config["CELERY_CONF"]["broker_url"]
-    parsed_result = urlparse(ctx.app.config["FLOWER_URL"])
-    address = f"--address={parsed_result.hostname}"
-    port = f"--port={parsed_result.port}"
-    args = [
-        "flower",
-        "-b",
-        broker,
-        address,
-        port,
-    ]
-    args += list(flower_args)
+    args = ["flower", "-b", broker] + list(flower_args)
     os.execvp(args[0], args)


### PR DESCRIPTION
Fix a potential deployement issue:
`DIRECTOR_FLOWER_URL` from the `.env`file was used for the `director celery flower`command when the URL should be used only for the front.
