### PR TITLE
feat(cli): add command for flask migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Celery Director provides an `init` command used to bootstrap a project :
 ```
 $ director init ~/workflows
 [*] Project created in /Users/ovh/workflows
+[*] Do not forget to initialize the database
 You can now export the DIRECTOR_HOME environment variable
 ```
 
@@ -69,7 +70,7 @@ ovh.SIMPLE_ETL:
     - LOAD
 ```
 
-You need to update the `.env` file with your own configuration (database, redis...) and create the director database :
+You need to update the `.env` file with your own configuration (database, Redis...) and create the director database :
 
 ```
 $ director db upgrade

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ ovh.SIMPLE_ETL:
 You need to update the `.env` file with your own configuration (database, redis...) and create the director database :
 
 ```
-$ director upgradedb
+$ director db upgrade
 ```
 
 You can now launch a worker and the webserver in 2 different shells :

--- a/director/cli.py
+++ b/director/cli.py
@@ -2,7 +2,7 @@ import click
 
 from director.commands.assets import dlassets
 from director.commands.celery import celery
-from director.commands.db import upgradedb
+from director.commands.db import db
 from director.commands.init import init
 from director.commands.webserver import webserver
 from director.commands.workflows import workflow
@@ -17,6 +17,6 @@ def cli():
 cli.add_command(webserver)
 cli.add_command(celery)
 cli.add_command(workflow)
-cli.add_command(upgradedb)
+cli.add_command(db)
 cli.add_command(dlassets)
 cli.add_command(init)

--- a/director/commands/db.py
+++ b/director/commands/db.py
@@ -1,17 +1,12 @@
-from pathlib import Path
+import os
 
 import click
-from alembic import command
-from alembic.config import Config
-
-from director.context import pass_ctx
 
 
-@click.command()
-@pass_ctx
-def upgradedb(ctx):
-    """Upgrade the database schema"""
-    path = Path(__file__).resolve().parent.parent
-    conf = Config(str(path / "migrations" / "alembic.ini"))
-    conf.set_main_option("script_location", str(path / "migrations"))
-    command.upgrade(conf, "heads")
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument("db_args", nargs=-1, type=click.UNPROCESSED)
+def db(db_args):
+    """Manage the database"""
+    os.environ["FLASK_APP"] = "director._auto:app"
+    args = ["flask", "db"] + list(db_args)
+    os.execvpe(args[0], args, os.environ)

--- a/director/commands/init.py
+++ b/director/commands/init.py
@@ -12,11 +12,11 @@ DIRECTOR_DATABASE_POOL_RECYCLE=-1
 # ---------- Celery ----------
 DIRECTOR_BROKER_URI="redis://127.0.0.1:6379/0"
 DIRECTOR_RESULT_BACKEND_URI="redis://127.0.0.1:6379/1"
-DIRECTOR_FLOWER_URL="http://127.0.0.1:5555"
 
 
 # ---------- Frontend ---------- 
 DIRECTOR_API_URL="http://127.0.0.1:8000/api"
+DIRECTOR_FLOWER_URL="http://127.0.0.1:5555"
 DIRECTOR_ENABLE_DARK_THEME=false
 
 # These settings are designed to be used with the "director dlassets" command,


### PR DESCRIPTION
- Give access to: `director db <flask migrate command>`
   E.g.: `director db upgrade` to initialize the database.
- Move the FLOWER URL to the frontend section in the `.env` template
- Fix some typos in the README.md