### PR TITLE
Relaunch workflows

### DIFF
--- a/director/api/__init__.py
+++ b/director/api/__init__.py
@@ -5,6 +5,11 @@ from flask import jsonify, Blueprint
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
 
+@api_bp.errorhandler(404)
+def not_found(error):
+    return jsonify({"error": error.description}), 404
+
+
 @api_bp.route("/ping")
 def ping():
     return jsonify({"message": "pong"})

--- a/director/api/workflows.py
+++ b/director/api/workflows.py
@@ -1,11 +1,40 @@
 from flask import current_app as app
-from flask import jsonify, request
+from flask import abort, jsonify, request
 
 from director.api import api_bp
 from director.builder import WorkflowBuilder
 from director.exceptions import WorkflowNotFound
 from director.extensions import cel_workflows, schema
 from director.models.workflows import Workflow
+
+
+def _get_workflow(workflow_id):
+    workflow = Workflow.query.filter_by(id=workflow_id).first()
+    if not workflow:
+        abort(404, f"Workflow {workflow_id} not found")
+    return workflow
+
+
+def _execute_workflow(project, name, payload={}):
+    fullname = f"{project}.{name}"
+
+    # Check if the workflow exists
+    try:
+        cel_workflows.get_by_name(fullname)
+    except WorkflowNotFound:
+        abort(404, f"Workflow {fullname} not found")
+
+    # Create the workflow in DB
+    obj = Workflow(project=project, name=name, payload=payload)
+    obj.save()
+
+    # Build the workflow and execute it
+    data = obj.to_dict()
+    workflow = WorkflowBuilder(obj.id)
+    workflow.run()
+
+    app.logger.info(f"Workflow sent : {workflow.canvas}")
+    return obj.to_dict(), workflow
 
 
 @api_bp.route("/workflows", methods=["POST"])
@@ -21,27 +50,19 @@ from director.models.workflows import Workflow
     }
 )
 def create_workflow():
-    data = request.get_json()
-    project = data["project"]
-    name = data["name"]
-    fullname = f"{project}.{name}"
+    project, name, payload = (
+        request.get_json()["project"],
+        request.get_json()["name"],
+        request.get_json()["payload"],
+    )
+    data, _ = _execute_workflow(project, name, payload)
+    return jsonify(data), 201
 
-    # Check if the workflow exists
-    try:
-        cel_workflows.get_by_name(fullname)
-    except WorkflowNotFound:
-        return jsonify({"error": f"Workflow {fullname} not found"}), 404
 
-    # Create the workflow in DB
-    obj = Workflow(project=project, name=name, payload=data["payload"])
-    obj.save()
-
-    # Build the workflow and execute it
-    data = obj.to_dict()
-    workflow = WorkflowBuilder(obj.id)
-    workflow.run()
-
-    app.logger.info(f"Workflow ready : {workflow.canvas}")
+@api_bp.route("/workflows/<workflow_id>/relaunch", methods=["POST"])
+def relaunch_workflow(workflow_id):
+    obj = _get_workflow(workflow_id)
+    data, _ = _execute_workflow(obj.project, obj.name, obj.payload)
     return jsonify(data), 201
 
 
@@ -53,12 +74,9 @@ def list_workflows():
 
 @api_bp.route("/workflows/<workflow_id>")
 def get_workflow(workflow_id):
-    workflow = Workflow.query.filter_by(id=workflow_id).first()
-    if not workflow:
-        return jsonify({"error": f"Workflow {workflow_id} not found"}), 404
-
+    workflow = _get_workflow(workflow_id)
     tasks = [t.to_dict() for t in workflow.tasks]
+
     resp = workflow.to_dict()
     resp.update({"tasks": tasks})
-
     return jsonify(resp)

--- a/director/static/script.js
+++ b/director/static/script.js
@@ -65,6 +65,12 @@ const store = new Vuex.Store({
     },
     selectTask({commit}, task) {
       commit('updateSelectedTask', task)
+    },
+    relaunchWorkflow({commit, dispatch}, workflow_id) {
+      axios.post(API_URL + "/workflows/" + workflow_id + "/relaunch").then((response) => {
+        dispatch("listWorkflows")
+        dispatch("getWorkflow", response.data.id)
+      });
     }
   },
   mutations: {
@@ -162,8 +168,9 @@ new Vue({
     }),
     data: () => ({
       drawer: null,
-      dialog: false,
-      dialogTask: false,
+      payloadDialog: false,
+      taskDialog: false,
+      relaunchDialog: false,
       search: '',
       headers: [
         {
@@ -192,7 +199,11 @@ new Vue({
       },
       displayTask: function(task) {
         this.$store.dispatch('selectTask', task);
-        this.dialogTask = true;
+        this.taskDialog = true;
+      },
+      relaunchWorkflow: function() {
+        this.$store.dispatch('relaunchWorkflow', this.selectedWorkflow.id);
+        this.relaunchDialog = false;
       },
       getFlowerTaskUrl: function() {
         return FLOWER_URL + "/task/" + this.selectedTask.id;

--- a/director/templates/index.html
+++ b/director/templates/index.html
@@ -87,27 +87,12 @@
                               <u>Tasks :</u> Total <strong>{{ selectedWorkflow.tasks.length }}</strong> / Success <strong>{{ selectedWorkflow.tasks | countTasksByStatus('success') }}</strong> / Error <strong>{{ selectedWorkflow.tasks | countTasksByStatus('error') }}</strong>
                             </v-list-item-subtitle>
                           </v-list-item-content>
-                          <v-dialog
-                            v-model="dialog"
-                            width="500"
-                          >
-                            <template v-slot:activator="{ on }">
-                              <v-btn class="ma-2" tile outlined color="director" disabled>
-                                <v-icon left>mdi-refresh</v-icon> Relaunch
-                              </v-btn>
-                              <v-btn tile outlined color="director" v-on="on">
-                                <v-icon left>mdi-format-list-bulleted</v-icon> Payload
-                              </v-btn>
-                            </template>
-
-                            <v-card>
-                              <v-card-title>Workflow's Payload</v-card-title>
-                              <v-divider></v-divider>
-                              <v-card-text class="mt-5">
-                                <pre>{{ selectedWorkflow.payload }}</pre>
-                              </v-card-text>
-                            </v-card>
-                          </v-dialog>
+                          <v-btn class="ma-2" tile outlined color="director" @click.stop="relaunchDialog = true">
+                            <v-icon left>mdi-refresh</v-icon> Relaunch
+                          </v-btn>
+                          <v-btn tile outlined color="director" @click.stop="payloadDialog = true">
+                            <v-icon left>mdi-format-list-bulleted</v-icon> Payload
+                          </v-btn>
                         </v-list-item>
                         <v-divider ></v-divider>
                       </div>
@@ -147,7 +132,7 @@
                 </v-col>
               </v-row>
             </v-container>
-            <v-dialog v-model="dialogTask" max-width="600">
+            <v-dialog v-model="taskDialog" max-width="600">
                 <v-card v-if="selectedTask">
                   <v-card-title>
                     Task
@@ -162,6 +147,37 @@
                   </v-card-text>
                 </v-card>
             </v-dialog>
+            <v-dialog v-model="relaunchDialog" max-width="650">
+              <v-card v-if="selectedWorkflow">
+                <v-card-title>
+                  Relaunch the workflow
+                  <v-spacer></v-spacer>
+                </v-card-title>
+                <v-divider></v-divider>
+                <v-card-text class="mt-5">
+                    <v-alert color="director" dark icon="mdi-alert-circle-outline" dense>
+                      The workflow <strong>{{ selectedWorkflow.fullname }}</strong> will be relaunched with the same payload.
+                    </v-alert>
+                    <i>Note that a new workflow will be created, so the current one (created on {{ selectedWorkflow.created | formatDate }}) will not be changed and will still be available in your history.</i>
+                </v-card-text>
+
+                <v-card-actions>
+                  <v-spacer></v-spacer>
+                  <div class="my-2 ma-2"><v-btn depressed @click.stop="relaunchDialog = false">Cancel</v-btn></div>
+                  <div class="my-2"><v-btn depressed color="primary" @click.stop="relaunchWorkflow()">Confirm</v-btn></div>
+                  </v-card-actions>
+
+              </v-card>
+          </v-dialog>
+          <v-dialog v-model="payloadDialog" width="500">
+            <v-card v-if="selectedWorkflow">
+              <v-card-title>Workflow's Payload</v-card-title>
+              <v-divider></v-divider>
+              <v-card-text class="mt-5">
+                <pre>{{ selectedWorkflow.payload }}</pre>
+              </v-card-text>
+            </v-card>
+          </v-dialog>
       
           </v-content>
       </v-app>


### PR DESCRIPTION
This PR allows a user to relaunch a workflow using API and UI (no task choice yet, the whole workflow is relaunched) :

```json
$ http POST :8000/api/workflows/309c1a62-625d-484e-ab63-027f7a31daf7/relaunch
HTTP/1.0 201 CREATED
Content-Length: 268
Content-Type: application/json
Date: Wed, 12 Feb 2020 21:47:27 GMT
Server: Werkzeug/1.0.0 Python/3.6.1

{
    "created": "2020-02-12T21:47:27",
    "fullname": "ovh.SIMPLE_ETL",
    "id": "9264587c-3d1a-4889-aba1-f0ed2684414c",
    "name": "SIMPLE_ETL",
    "payload": {},
    "periodic": false,
    "project": "ovh",
    "status": "pending",
    "updated": "2020-02-12T21:47:27"
}
```

![director_relaunch](https://user-images.githubusercontent.com/1552526/74380546-16e4c980-4dea-11ea-872d-2ee336e20e16.png)