### PR TITLE
fix(workflows): the state was wrong when last task raises a Celery error

### DIFF
--- a/director/tasks/workflows.py
+++ b/director/tasks/workflows.py
@@ -28,5 +28,7 @@ def start(workflow_id):
 def end(workflow_id):
     logger.info(f"Closing the workflow {workflow_id}")
     workflow = Workflow.query.filter_by(id=workflow_id).first()
-    workflow.status = StatusType.success
-    workflow.save()
+
+    if workflow.status != StatusType.error:
+        workflow.status = StatusType.success
+        workflow.save()

--- a/tests/workflows/tasks/error.py
+++ b/tests/workflows/tasks/error.py
@@ -4,3 +4,15 @@ from director import task
 @task(name="TASK_ERROR")
 def task_error(*args, **kwargs):
     print(1 / 0)
+
+
+@task(name="TASK_CELERY_ERROR")
+def task_celery_error(*args, **kwargs):
+    """
+    This task returns a non-serializable value.
+    """
+
+    class Foo(object):
+        pass
+
+    return Foo()

--- a/tests/workflows/workflows.yml
+++ b/tests/workflows/workflows.yml
@@ -41,3 +41,12 @@ schemas.SIMPLE_SCHEMA:
   tasks:
     - TASK_EXAMPLE
   schema: example/simple_schema
+
+example.CELERY_ERROR_ONE_TASK:
+  tasks:
+    - TASK_CELERY_ERROR
+
+example.CELERY_ERROR_MULTIPLE_TASKS:
+  tasks:
+    - TASK_A
+    - TASK_CELERY_ERROR


### PR DESCRIPTION
The workflow state was **success** even if the last task raises a Celery error (like an `EncodeError`) because the `end` function was still called.

Note this bug was not present if an an application error (not an internal Celery exception) was raised because the full canvas stopped and the end function was not called.

**Before**
![celery_error_1](https://user-images.githubusercontent.com/1552526/76165408-2fc96c00-6157-11ea-9d48-b0032a0e6835.png)

**After**
![celery_error_2](https://user-images.githubusercontent.com/1552526/76165409-32c45c80-6157-11ea-878a-13ae6720434f.png)