### PR TITLE
feat(api): limit the number of workflows to return

### DIFF
--- a/director/api/workflows.py
+++ b/director/api/workflows.py
@@ -71,8 +71,14 @@ def relaunch_workflow(workflow_id):
 
 @api_bp.route("/workflows")
 def list_workflows():
-    workflows = Workflow.query.all()
-    return jsonify([w.to_dict() for w in workflows])
+    page = request.args.get("page", type=int, default=1)
+    per_page = request.args.get(
+        "per_page", type=int, default=app.config["WORKFLOWS_PER_PAGE"]
+    )
+    workflows = Workflow.query.order_by(Workflow.created_at.desc()).paginate(
+        page, per_page
+    )
+    return jsonify([w.to_dict() for w in workflows.items])
 
 
 @api_bp.route("/workflows/<workflow_id>")

--- a/director/commands/init.py
+++ b/director/commands/init.py
@@ -19,6 +19,9 @@ DIRECTOR_API_URL="http://127.0.0.1:8000/api"
 DIRECTOR_FLOWER_URL="http://127.0.0.1:5555"
 DIRECTOR_ENABLE_DARK_THEME=false
 
+# ---------- API ----------
+DIRECTOR_WORKFLOWS_PER_PAGE=1000
+
 # These settings are designed to be used with the "director dlassets" command,
 # the DIRECTOR_STATIC_FOLDER will be used if you set DIRECTOR_ENABLE_CDN to false.
 DIRECTOR_ENABLE_CDN=true

--- a/director/settings.py
+++ b/director/settings.py
@@ -38,6 +38,7 @@ class Config(object):
         )
         self.API_URL = env.str("DIRECTOR_API_URL", "http://127.0.0.1:8000/api")
         self.FLOWER_URL = env.str("DIRECTOR_FLOWER_URL", "http://127.0.0.1:5555")
+        self.WORKFLOWS_PER_PAGE = env.int("WORKFLOWS_PER_PAGE", 1000)
 
         # SQLAlchemy configuration
         self.SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -12,6 +12,11 @@ Host: example.com
 Accept: application/json
 ```
 
+**Parameters:**
+
+- `per_page` (optional, default: 1000): the number of workflows to return
+- `page` (optional, default: 1): the page to start
+
 **Example response:**
 
 ```


### PR DESCRIPTION
The UI pagination is directly done by Vue.js using the whole response of `GET /api/workflows`.

However, after a certain period (which may vary widely), the response is too big and UI becomes unusable.

Now the API returns **1000** workflows by default, so the UI remains usable. The value can be changed with the `DIRECTOR_WORKFLOWS_PER_PAGE` configuration.

And it's still possible to fetch very old workflows using the API and the `per_page` and `page` arguments  :

```
$ curl -X GET "http://127.0.0.1:8000/api/workflows?per_page=100&page=1234"
```

