### PR TITLE
fix: avoid "idle in transaction" problems on PostgreSQL

### DIFF
--- a/director/models/__init__.py
+++ b/director/models/__init__.py
@@ -42,6 +42,13 @@ class BaseModel(db.Model):
             db.session.rollback()
             raise
 
+    def commit(self):
+        try:
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise
+
     def to_dict(self):
         return {
             "id": self.id,

--- a/director/models/__init__.py
+++ b/director/models/__init__.py
@@ -34,20 +34,16 @@ class BaseModel(db.Model):
         nullable=False,
     )
 
-    def save(self):
-        try:
-            db.session.add(self)
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-            raise
-
     def commit(self):
         try:
             db.session.commit()
         except Exception:
             db.session.rollback()
             raise
+
+    def save(self):
+        db.session.add(self)
+        self.commit()
 
     def to_dict(self):
         return {

--- a/director/models/users.py
+++ b/director/models/users.py
@@ -25,20 +25,12 @@ class User(BaseModel):
 
         user.password = self.password
 
-        try:
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-            raise
+        self.commit()
 
     def delete(self):
         db.session.delete(self)
 
-        try:
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-            raise
+        self.commit()
 
     def to_dict(self):
         d = super().to_dict()

--- a/director/tasks/periodic.py
+++ b/director/tasks/periodic.py
@@ -13,4 +13,10 @@ def execute(workflow, payload):
     workflow = WorkflowBuilder(c_obj.id)
     workflow.run()
 
-    return c_obj.to_dict()
+    c_obj_dict = c_obj.to_dict()
+
+    # Force commit before ending the function to ensure the ongoing transaction
+    # does not end up in a "idle in transaction" state on PostgreSQL
+    c_obj.commit()
+
+    return c_obj_dict


### PR DESCRIPTION
fix: avoid "idle in transaction" problems on PostgreSQL following multiple queues implementation

Signed-off-by: Maxime Caruchet <maxime.caruchet@corp.ovh.com>