### PR TITLE
chore: add Ismail and Arnaud as default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default reviewers
-*       @ncrocfer @anthonyolea @ziirish @maximecaruchet
+*       @ncrocfer @anthonyolea @ziirish @maximecaruchet @ministicraft @ismailrei


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@corp.ovh.com>