### PR TITLE
fix(migration): Add type deletion during downgrade

### DIFF
--- a/director/migrations/versions/30d6f6636351_initial_migration.py
+++ b/director/migrations/versions/30d6f6636351_initial_migration.py
@@ -72,3 +72,4 @@ def downgrade():
     op.drop_table("tasks")
     op.drop_index(op.f("ix_workflows_created_at"), table_name="workflows")
     op.drop_table("workflows")
+    sa.Enum(name="statustype").drop(op.get_bind())


### PR DESCRIPTION
If the database engine is Postgres, Enums are saved as types in the database. So, they need to be deleted while downgrading. 
Using `.drop()` allow to drop it if it's needed (e.g. with Postgres) and do nothing if type are not saved in the database (e.g. SQLite).
This PR should solve issue #69 