### PR TITLE
fix: mysql string column length is required

### DIFF
--- a/director/migrations/versions/30d6f6636351_initial_migration.py
+++ b/director/migrations/versions/30d6f6636351_initial_migration.py
@@ -25,8 +25,8 @@ def upgrade():
         sa.Column("id", UUIDType(binary=False), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
-        sa.Column("project", sa.String(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("project", sa.String(255), nullable=False),
         sa.Column(
             "status",
             sa.Enum(
@@ -47,7 +47,7 @@ def upgrade():
         sa.Column("id", UUIDType(binary=False), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("key", sa.String(255), nullable=False),
         sa.Column(
             "status",
             sa.Enum(

--- a/director/migrations/versions/3f8466b16023_add_users_table.py
+++ b/director/migrations/versions/3f8466b16023_add_users_table.py
@@ -24,8 +24,8 @@ def upgrade():
         sa.Column("id", UUIDType(binary=False), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("username", sa.String(), nullable=False),
-        sa.Column("password", sa.String(), nullable=False),
+        sa.Column("username", sa.String(255), nullable=False),
+        sa.Column("password", sa.String(255), nullable=False),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_users")),
         sa.UniqueConstraint("username", name=op.f("uq_users_username")),
     )

--- a/director/models/tasks.py
+++ b/director/models/tasks.py
@@ -11,7 +11,7 @@ from director.models.utils import JSONBType
 class Task(BaseModel):
     __tablename__ = "tasks"
 
-    key = db.Column(db.String(), nullable=False)
+    key = db.Column(db.String(255), nullable=False)
     status = db.Column(db.Enum(StatusType), default=StatusType.pending, nullable=False)
     previous = db.Column(JSONBType, default=[])
     result = db.Column(PickleType)

--- a/director/models/users.py
+++ b/director/models/users.py
@@ -12,8 +12,8 @@ from director.models.utils import JSONBType
 class User(BaseModel):
     __tablename__ = "users"
 
-    username = db.Column(db.String(), unique=True, nullable=False)
-    password = db.Column(db.String(), nullable=False)
+    username = db.Column(db.String(255), unique=True, nullable=False)
+    password = db.Column(db.String(255), nullable=False)
 
     def __repr__(self):
         return f"<User {self.username}>"

--- a/director/models/workflows.py
+++ b/director/models/workflows.py
@@ -6,8 +6,8 @@ from director.models.utils import JSONBType
 class Workflow(BaseModel):
     __tablename__ = "workflows"
 
-    name = db.Column(db.String(), nullable=False)
-    project = db.Column(db.String(), nullable=False)
+    name = db.Column(db.String(255), nullable=False)
+    project = db.Column(db.String(255), nullable=False)
     status = db.Column(db.Enum(StatusType), default=StatusType.pending, nullable=False)
     payload = db.Column(JSONBType, default={})
     periodic = db.Column(db.Boolean, default=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ kombu==4.6.7
 psycopg2-binary==2.8.4
 SQLAlchemy==1.3.11
 sqlalchemy-utils==0.35.0
+mysql-connector-python==8.0.21
 redis==3.3.11
 alembic==1.3.2
 


### PR DESCRIPTION
## Issue
`VARCHAR` lenght is require in MySQL 5.7

## Error
"VARCHAR requires a length on dialect %s" % self.dialect.name
sqlalchemy.exc.CompileError: (in table 'workflows', column 'name'): VARCHAR requires a length on dialect mysql

## Reproduction
Put `DIRECTOR_DATABASE_URI=<proper_mysql_5.7_uri>` into `.env` file
Run `director db upgrade`

## Fix suggestion
Added fixed length to `sa.String()` occurrences