### PR TITLE
fix: make sure the session is rolled back when an unhandled exception occurred during the request.

### DIFF
--- a/director/__init__.py
+++ b/director/__init__.py
@@ -98,6 +98,10 @@ def create_app(
                 }
             )
 
+    @app.teardown_request
+    def session_clear(exception=None):
+        db.session.remove()
+
     return app
 
 

--- a/director/tasks/base.py
+++ b/director/tasks/base.py
@@ -22,6 +22,15 @@ def director_prerun(task_id, task, *args, **kwargs):
         task.save()
 
 
+@task_postrun.connect
+def close_session(*args, **kwargs):
+    # Flask SQLAlchemy will automatically create new sessions for you from
+    # a scoped session factory, given that we are maintaining the same app
+    # context, this ensures tasks have a fresh session (e.g. session errors
+    # won't propagate across tasks)
+    db.session.remove()
+
+
 class BaseTask(_Task):
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         task = Task.query.filter_by(id=task_id).first()


### PR DESCRIPTION
This should fix errors such as "InvalidRequestError: Can't reconnect
until invalid transaction is rolled back"

Signed-off-by: Benjamin SANS <benjamin.sans@corp.ovh.com>