### PR TITLE
chore(db): add sql queries from alembic migrations

### DIFF
--- a/director/migrations/sql/postgres/000_30d6f6636351_initial_migration.sql
+++ b/director/migrations/sql/postgres/000_30d6f6636351_initial_migration.sql
@@ -1,0 +1,55 @@
+-- +migrate Up
+
+CREATE TABLE alembic_version (
+    version_num VARCHAR(32) NOT NULL, 
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+
+CREATE TYPE statustype AS ENUM ('pending', 'progress', 'success', 'error', 'canceled');
+
+CREATE TABLE workflows (
+    id UUID NOT NULL, 
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    name VARCHAR(255) NOT NULL, 
+    project VARCHAR(255) NOT NULL, 
+    status statustype NOT NULL, 
+    payload JSONB, 
+    periodic BOOLEAN, 
+    CONSTRAINT pk_workflows PRIMARY KEY (id)
+);
+
+CREATE INDEX ix_workflows_created_at ON workflows (created_at);
+
+CREATE TABLE tasks (
+    id UUID NOT NULL, 
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    key VARCHAR(255) NOT NULL, 
+    status statustype NOT NULL, 
+    previous JSONB, 
+    workflow_id UUID NOT NULL, 
+    CONSTRAINT pk_tasks PRIMARY KEY (id), 
+    CONSTRAINT fk_tasks_workflow_id_workflows FOREIGN KEY(workflow_id) REFERENCES workflows (id)
+);
+
+CREATE INDEX ix_tasks_created_at ON tasks (created_at);
+
+INSERT INTO alembic_version (version_num) VALUES ('30d6f6636351');
+
+
+-- +migrate Down
+
+DROP INDEX ix_tasks_created_at;
+
+DROP TABLE tasks;
+
+DROP INDEX ix_workflows_created_at;
+
+DROP TABLE workflows;
+
+DROP TYPE statustype;
+
+DELETE FROM alembic_version WHERE alembic_version.version_num = '30d6f6636351';
+
+DROP TABLE alembic_version;

--- a/director/migrations/sql/postgres/001_05cf96d6fcae_add_task_result.sql
+++ b/director/migrations/sql/postgres/001_05cf96d6fcae_add_task_result.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE tasks ADD COLUMN result BYTEA;
+
+UPDATE alembic_version SET version_num='05cf96d6fcae' WHERE alembic_version.version_num = '30d6f6636351';
+
+
+-- +migrate Down
+
+ALTER TABLE tasks DROP COLUMN result;
+
+UPDATE alembic_version SET version_num='30d6f6636351' WHERE alembic_version.version_num = '05cf96d6fcae';

--- a/director/migrations/sql/postgres/002_3f8466b16023_add_users_table.sql
+++ b/director/migrations/sql/postgres/002_3f8466b16023_add_users_table.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+
+CREATE TABLE users (
+    id UUID NOT NULL, 
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+    username VARCHAR(255) NOT NULL, 
+    password VARCHAR(255) NOT NULL, 
+    CONSTRAINT pk_users PRIMARY KEY (id), 
+    CONSTRAINT uq_users_username UNIQUE (username)
+);
+
+CREATE INDEX ix_users_created_at ON users (created_at);
+
+UPDATE alembic_version SET version_num='3f8466b16023' WHERE alembic_version.version_num = '05cf96d6fcae';
+
+
+-- +migrate Down
+
+DROP INDEX ix_users_created_at;
+
+DROP TABLE users;
+
+UPDATE alembic_version SET version_num='05cf96d6fcae' WHERE alembic_version.version_num = '3f8466b16023';

--- a/director/migrations/sql/postgres/003_063ff371f2da_add_index_on_workflow_id_in_task_table.sql
+++ b/director/migrations/sql/postgres/003_063ff371f2da_add_index_on_workflow_id_in_task_table.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+CREATE INDEX ix_tasks_workflow_id ON tasks (workflow_id);
+
+UPDATE alembic_version SET version_num='063ff371f2da' WHERE alembic_version.version_num = '3f8466b16023';
+
+
+-- +migrate Down
+
+DROP INDEX ix_tasks_workflow_id;
+
+UPDATE alembic_version SET version_num='3f8466b16023' WHERE alembic_version.version_num = '063ff371f2da';

--- a/director/migrations/sql/postgres/004_2ac615d6850b_force_varchar_255.sql
+++ b/director/migrations/sql/postgres/004_2ac615d6850b_force_varchar_255.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+
+ALTER TABLE tasks ALTER COLUMN key TYPE VARCHAR(255);
+
+ALTER TABLE users ALTER COLUMN password TYPE VARCHAR(255);
+
+ALTER TABLE users ALTER COLUMN username TYPE VARCHAR(255);
+
+ALTER TABLE workflows ALTER COLUMN name TYPE VARCHAR(255);
+
+ALTER TABLE workflows ALTER COLUMN project TYPE VARCHAR(255);
+
+UPDATE alembic_version SET version_num='2ac615d6850b' WHERE alembic_version.version_num = '063ff371f2da';
+
+
+-- +migrate Down
+
+ALTER TABLE workflows ALTER COLUMN project TYPE VARCHAR;
+
+ALTER TABLE workflows ALTER COLUMN name TYPE VARCHAR;
+
+ALTER TABLE users ALTER COLUMN username TYPE VARCHAR;
+
+ALTER TABLE users ALTER COLUMN password TYPE VARCHAR;
+
+ALTER TABLE tasks ALTER COLUMN key TYPE VARCHAR;
+
+UPDATE alembic_version SET version_num='063ff371f2da' WHERE alembic_version.version_num = '2ac615d6850b';


### PR DESCRIPTION
Add SQL output from Alembic migration files for the Postgres database.

_NB: a PG v9.6.7 server was configured when generating the queries._
