### PR TITLE
Refactoring periodic section in workflow declaration

### DIFF
--- a/director/__init__.py
+++ b/director/__init__.py
@@ -13,7 +13,7 @@ from director.extensions import cel, cel_workflows, db, schema, sentry, migrate
 from director.settings import Config, UserConfig
 from director.tasks.base import BaseTask
 from director.views import view_bp
-from director.utils import build_celery_schedule
+from director.utils import build_celery_schedule, read_schedule
 
 with open(Path(__file__).parent.resolve() / "VERSION", encoding="utf-8") as version:
     __version__ = version.readline().rstrip()
@@ -84,8 +84,9 @@ def create_app(
     for workflow, conf in cel_workflows.workflows.items():
         if "periodic" in conf:
             payload = conf.get("periodic").get("payload", {})
-            workflow_schedule = conf.get("periodic").get("schedule")
-            schedule = build_celery_schedule(workflow, workflow_schedule)
+            schedule_type = read_schedule(workflow, conf.get("periodic").keys())
+            workflow_schedule = conf.get("periodic").get(schedule_type)
+            schedule = build_celery_schedule(workflow, workflow_schedule, schedule_type)
 
             cel.conf.beat_schedule.update(
                 {

--- a/director/commands/workflows.py
+++ b/director/commands/workflows.py
@@ -10,7 +10,7 @@ from director.context import pass_ctx
 from director.exceptions import WorkflowNotFound
 from director.extensions import cel_workflows
 from director.models.workflows import Workflow
-from director.utils import validate, format_schema_errors, read_schedule
+from director.utils import validate, format_schema_errors, build_celery_schedule
 
 
 def tasks_to_ascii(tasks):
@@ -50,8 +50,9 @@ def list_workflow(ctx):
 
     # Add a row for each workflow
     for name, conf in workflows.items():
-        periodic_k = read_schedule(name, conf.get("periodic", {}).keys())
-        periodic = conf.get("periodic", {}).get(periodic_k, "--")
+        periodic = "--"
+        if conf.get("periodic"):
+            periodic, _ = build_celery_schedule(name, conf["periodic"])
         tasks_str = tasks_to_ascii(conf["tasks"])
         data.append([name, periodic, tasks_str])
 
@@ -73,8 +74,9 @@ def show_workflow(ctx, name):
         raise click.Abort()
 
     tasks_str = tasks_to_ascii(_workflow["tasks"])
-    periodic_k = read_schedule(_workflow, _workflow.get("periodic", {}).keys())
-    periodic = _workflow.get("periodic", {}).get(periodic_k, "--")
+    periodic = "--"
+    if _workflow.get("periodic"):
+        periodic, _ = build_celery_schedule(name, _workflow["periodic"])
     payload = _workflow.get("periodic", {}).get("payload", {})
 
     # Construct the table

--- a/director/commands/workflows.py
+++ b/director/commands/workflows.py
@@ -10,7 +10,7 @@ from director.context import pass_ctx
 from director.exceptions import WorkflowNotFound
 from director.extensions import cel_workflows
 from director.models.workflows import Workflow
-from director.utils import validate, format_schema_errors
+from director.utils import validate, format_schema_errors, read_schedule
 
 
 def tasks_to_ascii(tasks):
@@ -50,7 +50,8 @@ def list_workflow(ctx):
 
     # Add a row for each workflow
     for name, conf in workflows.items():
-        periodic = conf.get("periodic", {}).get("schedule", "--")
+        periodic_k = read_schedule(name, conf.get("periodic", {}).keys())
+        periodic = conf.get("periodic", {}).get(periodic_k, "--")
         tasks_str = tasks_to_ascii(conf["tasks"])
         data.append([name, periodic, tasks_str])
 
@@ -72,7 +73,8 @@ def show_workflow(ctx, name):
         raise click.Abort()
 
     tasks_str = tasks_to_ascii(_workflow["tasks"])
-    periodic = _workflow.get("periodic", {}).get("schedule", "--")
+    periodic_k = read_schedule(_workflow, _workflow.get("periodic", {}).keys())
+    periodic = _workflow.get("periodic", {}).get(periodic_k, "--")
     payload = _workflow.get("periodic", {}).get("payload", {})
 
     # Construct the table

--- a/director/static/script.js
+++ b/director/static/script.js
@@ -163,7 +163,7 @@ const store = new Vuex.Store({
 
 Vue.filter('formatDate', function(value) {
   if (value) {
-    return moment(String(value)).format('YYYY-MM-DD HH:mm:ss')
+    return moment.utc(value).local().format('YYYY-MM-DD HH:mm:ss Z');
   }
 });
 
@@ -197,7 +197,7 @@ new Vue({
           text: 'Status',
           align: 'left',
           value: 'status',
-          width: '17%',
+          width: '14%',
           filter: value => {
             if (this.selectedStatus.length == 0) return true
             return this.selectedStatus.includes(value)
@@ -207,7 +207,7 @@ new Vue({
           text: 'Name',
           align: 'left',
           value: 'fullname',
-          width: '58%',
+          width: '56%',
           filter: value => {
             if (!this.selectedWorkflowName || this.selectedWorkflowName == 'All') return true
             return value == this.selectedWorkflowName
@@ -217,7 +217,7 @@ new Vue({
           text: 'Date',
           align: 'left',
           value: 'created',
-          width: '25%',
+          width: '30%',
 
         },
       ]

--- a/director/templates/index.html
+++ b/director/templates/index.html
@@ -58,7 +58,7 @@
                           </td>
                           <td>{{ item.fullname }}</td>
                           <td>
-                            <v-ship>{{ item.created }}</v-ship>
+                            <v-ship>{{ item.created | formatDate }}</v-ship>
                           </td>
                         </tr>
                       </template>

--- a/director/utils.py
+++ b/director/utils.py
@@ -29,7 +29,6 @@ def build_celery_schedule(workflow, data):
         try:
             value = float(schedule)
         except ValueError:
-            print("here")
             m, h, dw, dm, my = schedule.split(" ")
             value = crontab(
                 minute=m,
@@ -45,9 +44,9 @@ def build_celery_schedule(workflow, data):
         return crontab(
             minute=m,
             hour=h,
-            day_of_week=dw,
             day_of_month=dm,
             month_of_year=my,
+            day_of_week=dw,
         )
 
     excluded_keys = ["payload"]

--- a/director/utils.py
+++ b/director/utils.py
@@ -22,7 +22,7 @@ def format_schema_errors(e):
     }
 
 
-def build_celery_schedule(workflow, data):
+def build_celery_schedule(workflow_name, data):
     """A celery schedule can accept seconds or crontab"""
 
     def _handle_schedule(schedule):
@@ -62,7 +62,7 @@ def build_celery_schedule(workflow, data):
 
     if len(keys) != 1 or keys[0] not in schedule_functions.keys():
         # When there is no key (schedule, interval, crontab) in the periodic configuration
-        raise WorkflowSyntaxError(workflow)
+        raise WorkflowSyntaxError(workflow_name)
 
     schedule_key = keys[0]
     schedule_input = data[schedule_key]
@@ -70,4 +70,4 @@ def build_celery_schedule(workflow, data):
         # Apply the function mapped to the schedule type
         return str(schedule_input), schedule_functions[schedule_key](schedule_input)
     except Exception:
-        raise WorkflowSyntaxError(workflow)
+        raise WorkflowSyntaxError(workflow_name)

--- a/director/utils.py
+++ b/director/utils.py
@@ -22,14 +22,13 @@ def format_schema_errors(e):
     }
 
 
-def build_celery_schedule(workflow_name, data):
-    """ A celery schedule can accept seconds or crontab """
+def build_celery_schedule(workflow, data, option):
+    """A celery schedule can accept seconds or crontab"""
     try:
-        schedule = float(data)
-    except ValueError:
-        try:
-            m, h, dw, dm, my = data.split(" ")
-
+        if option == "interval":
+            schedule = float(data)
+        elif option == "crontab":
+            m, h, dm, my, dw = data.split(" ")
             schedule = crontab(
                 minute=m,
                 hour=h,
@@ -37,7 +36,26 @@ def build_celery_schedule(workflow_name, data):
                 day_of_month=dm,
                 month_of_year=my,
             )
-        except Exception as e:
-            raise WorkflowSyntaxError(workflow_name)
+        elif option == "schedule":
+            m, h, dw, dm, my = data.split(" ")
+            schedule = crontab(
+                minute=m,
+                hour=h,
+                day_of_month=dm,
+                month_of_year=my,
+                day_of_week=dw,
+            )
+        else:
+            raise WorkflowSyntaxError(workflow)
+    except Exception as e:
+        raise WorkflowSyntaxError(workflow)
 
     return schedule
+
+
+def read_schedule(workflow, keys):
+    """Get the periodic key from workflow (interval, crontab or schedule)"""
+    periodic = set.intersection(set(keys), {"crontab", "interval", "schedule"})
+    if len(periodic) > 1:
+        raise WorkflowSyntaxError(workflow)
+    return next(iter(periodic), None)

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -77,7 +77,7 @@ the [Celery beat](https://docs.celeryproject.org/en/latest/userguide/periodic-ta
 
 Director allows you to periodically schedule a whole workflow using a simple YAML syntax.
 
-You can use the `periodic > interval` key with a number argument (unity is the second):
+You can use the `periodic > interval` key with a number argument (in seconds):
 
 ```yaml
 example.CHAIN:
@@ -114,6 +114,16 @@ So in the first example, the *example.CHAIN* workflow will be executed **every 6
     Older versions of Celery Director used the `periodic > schedule` key which is now deprecated.
 
     It is strongly advised to migrate to `periodic > interval` or `periodic > crontab` keys to set up a scheduled workflow.
+
+    How to migrate:
+
+    * **If your schedule is in seconds**: just rename `schedule` to `interval`;
+    * **If your schedule is a crontab**: rename `schedule` to `crontab`.
+
+        Be careful when migrating from `schedule` to `crontab`, there is also a fix to apply.
+        The old `schedule` syntax incorrectly parses the string as `minute hour day_of_week day_of_month month_of_year` but the `crontab` syntax properly parses the string as `minute hour day_of_month month_of_year day_of_week`.
+
+        For example: `0 12 1 * *` should become `0 12 * * 1` for a scheduled workflow at 12:00 UTC on Monday.
 
 Please note that the scheduler must be started to handle periodic workflows :
 

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -111,7 +111,9 @@ periodic:
 So in the first example, the *example.CHAIN* workflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
 
 !!! warning
-    The `periodic > schedule` key is deprecated. It is strongly advised to migrate to `interval` or `crontab` key to set up a scheduled workflow.
+    Older versions of Celery Director used the `periodic > schedule` key which is now deprecated.
+
+    It is strongly advised to migrate to `periodic > interval` or `periodic > crontab` keys to set up a scheduled workflow.
 
 Please note that the scheduler must be started to handle periodic workflows :
 

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -86,7 +86,7 @@ example.CHAIN:
     - B
     - C
   periodic:
-    schedule: 60
+    interval: 60
 ```
 
 Second example:
@@ -98,13 +98,16 @@ example.CHAIN_CRONTAB:
     - B
     - C
   periodic:
-    schedule: "0 */3 * * *"
+    crontab: "0 */3 * * *"
 ```
 
-The `periodic > schedule` key takes an integer (unity is the second) or a string argument
-([crontab](https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules)
-syntax). So in the first example, the *example.CHAIN* worflow will be executed **every 60 seconds**
-and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
+The `periodic > interval` key takes an integer (unity is the second) or using `periodic > crontab ` key a string argument ([crontab](https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules) syntax). So in the first example, the *example.CHAIN* worflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
+
+
+!!! warning
+    The `periodic > schedule` key is deprecated. It is strongly advised to migrate to `interval` or `crontab` key to set up scheduler.
+
+
 
 Please note that the scheduler must be started to handle periodic workflows :
 

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -101,11 +101,11 @@ example.CHAIN_CRONTAB:
     crontab: "0 */3 * * *"
 ```
 
-The `periodic > interval` key takes an integer (unity is the second) or using `periodic > crontab ` key a string argument ([crontab](https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules) syntax). So in the first example, the *example.CHAIN* worflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
+The `periodic > interval` key takes a number (unity is the second) or using `periodic > crontab ` key a string argument ([crontab](https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules) syntax). So in the first example, the *example.CHAIN* workflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
 
 
 !!! warning
-    The `periodic > schedule` key is deprecated. It is strongly advised to migrate to `interval` or `crontab` key to set up scheduler.
+    The `periodic > schedule` key is deprecated. It is strongly advised to migrate to `interval` or `crontab` key to set up a scheduled workflow.
 
 
 

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -105,7 +105,7 @@ The format is the following (the [official documentation](https://docs.celerypro
 
 ```yaml
 periodic:
-  crontab: "minute hour day_of_week day_of_month month_of_year"
+  crontab: "minute hour day_of_month month_of_year day_of_week"
 ```
 
 So in the first example, the *example.CHAIN* workflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.

--- a/docs/docs/guides/build-workflows.md
+++ b/docs/docs/guides/build-workflows.md
@@ -77,7 +77,7 @@ the [Celery beat](https://docs.celeryproject.org/en/latest/userguide/periodic-ta
 
 Director allows you to periodically schedule a whole workflow using a simple YAML syntax.
 
-First example:
+You can use the `periodic > interval` key with a number argument (unity is the second):
 
 ```yaml
 example.CHAIN:
@@ -89,7 +89,7 @@ example.CHAIN:
     interval: 60
 ```
 
-Second example:
+You can also use the `periodic > crontab` key with a string argument:
 
 ```yaml
 example.CHAIN_CRONTAB:
@@ -101,13 +101,17 @@ example.CHAIN_CRONTAB:
     crontab: "0 */3 * * *"
 ```
 
-The `periodic > interval` key takes a number (unity is the second) or using `periodic > crontab ` key a string argument ([crontab](https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules) syntax). So in the first example, the *example.CHAIN* workflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
+The format is the following (the [official documentation](https://docs.celeryproject.org/en/v4.4.7/userguide/periodic-tasks.html#crontab-schedules) of the `crontab` function gives some examples of each attribute):
 
+```yaml
+periodic:
+  crontab: "minute hour day_of_week day_of_month month_of_year"
+```
+
+So in the first example, the *example.CHAIN* workflow will be executed **every 60 seconds** and the second one, *example.CHAIN_CRONTAB*, **every three hours**.
 
 !!! warning
     The `periodic > schedule` key is deprecated. It is strongly advised to migrate to `interval` or `crontab` key to set up a scheduled workflow.
-
-
 
 Please note that the scheduler must be started to handle periodic workflows :
 

--- a/docs/docs/guides/use-payload.md
+++ b/docs/docs/guides/use-payload.md
@@ -117,7 +117,7 @@ users.UPDATE_CACHE:
   tasks:
     - UPDATE_CACHE
   periodic:
-    schedule: 3600
+    interval: 3600
     payload: {"user": False}
 ```
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -381,10 +381,10 @@ def test_build_celery_invalid_crontab():
 def test_build_celery_invalid_schedule():
     cron_schedule = {"crontab": "* * * * 12"}
     with pytest.raises(WorkflowSyntaxError):
-        build_celery_schedule("workflow_cron_invalid_cron", cron_schedule)
+        build_celery_schedule("workflow_invalid_crontab", cron_schedule)
 
 
 def test_build_celery_invalid_periodic_key():
     cron_schedule = {"non_valid_key": "* * * * *"}
     with pytest.raises(WorkflowSyntaxError):
-        build_celery_schedule("workflow_cron_invalid_key", cron_schedule)
+        build_celery_schedule("workflow_invalid_key", cron_schedule)


### PR DESCRIPTION
Replace PR #102
Co-authored with @PaulinCharliquart 

Do not change current behaviour when using (`workflows.yml`):
```yaml
periodic:
   schedule: ...
 ```
Introduce keys:
```yaml
periodic:
   interval: 42
```
 or
```yaml
periodic:
   crontab: "42 * * * *"
 ```
