### PR TITLE
Celery 5.1.2 compliance

### DIFF
--- a/director/commands/celery.py
+++ b/director/commands/celery.py
@@ -18,9 +18,9 @@ def beat(dev_mode, beat_args):
     """Start the beat instance"""
     args = [
         "celery",
-        "beat",
         "-A",
         "director._auto:cel",
+        "beat",
     ]
     if dev_mode:
         args += [
@@ -38,9 +38,9 @@ def worker(dev_mode, worker_args):
     """Start a Celery worker instance"""
     args = [
         "celery",
-        "worker",
         "-A",
         "director._auto:cel",
+        "worker",
     ]
     if dev_mode:
         args += [

--- a/director/extensions.py
+++ b/director/extensions.py
@@ -1,5 +1,6 @@
 import imp
 import json
+from os import sep
 from pathlib import Path
 from json.decoder import JSONDecodeError
 
@@ -61,7 +62,7 @@ class CeleryWorkflow:
                 if task.stem == "__init__":
                     continue
 
-                name = str(task.relative_to(folder))[:-3].replace("/", ".")
+                name = str(task.relative_to(folder))[:-3].replace(sep, ".")
                 __import__(
                     self.plugin_source.base.package + "." + name,
                     globals(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # Celery Packages
-celery==4.4.7
-flower==0.9.3
-kombu==4.6.11
+celery==5.1.2
+flower==1.0.0
+kombu==5.1.0
 
 # Databases
 psycopg2-binary==2.8.4
 SQLAlchemy==1.3.11
 sqlalchemy-utils==0.35.0
 mysql-connector-python==8.0.21
-redis==3.3.11
+redis==3.5.3
 alembic==1.3.2
 
 # Flask
@@ -20,10 +20,10 @@ Flask-HTTPAuth==4.1.0
 Werkzeug==1.0.1
 
 # Misc
-gunicorn==20.0.4
+gunicorn==20.1.0
 environs==6.1.0
 pyyaml==5.4.1
-click==7.0
+click==7.1.2
 terminaltables==3.1.0
-pluginbase==1.0.0
+pluginbase==1.0.1
 sentry-sdk==0.16.3


### PR DESCRIPTION
Celery 5.1.2 compliance & fix windows issue on os separator

Note : Windows might only works if 'gunicorn' is replaced with 'waitress'