### PR TITLE
feat: add support for with_payload arg on list workflows call

### DIFF
--- a/director/models/workflows.py
+++ b/director/models/workflows.py
@@ -18,16 +18,17 @@ class Workflow(BaseModel):
     def __repr__(self):
         return f"<Workflow {self.project}.{self.name}>"
 
-    def to_dict(self):
+    def to_dict(self, with_payload=True):
         d = super().to_dict()
         d.update(
             {
                 "name": self.name,
-                "payload": self.payload,
                 "project": self.project,
                 "fullname": f"{self.project}.{self.name}",
                 "status": self.status.value,
                 "periodic": self.periodic,
             }
         )
+        if with_payload:
+            d["payload"] = self.payload
         return d

--- a/director/static/script.js
+++ b/director/static/script.js
@@ -50,7 +50,7 @@ const store = new Vuex.Store({
     listWorkflows({
       commit
     }) {
-      axios.get(API_URL + "/workflows").then((response) => {
+      axios.get(API_URL + "/workflows?with_payload=false").then((response) => {
         commit('updateWorkflows', response.data)
         commit('changeLoadingState', false)
       })
@@ -285,7 +285,7 @@ new Vue({
         this.$store.dispatch('listWorkflows');
       },
       REFRESH_INTERVAL);
-    
+
     let workflowID = this.$route.params.id;
     if (workflowID) {
       this.$store.dispatch('getWorkflow', workflowID);

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -16,6 +16,7 @@ Accept: application/json
 
 - `per_page` (optional, default: 1000): the number of workflows to return
 - `page` (optional, default: 1): the page to start
+- `with_payload` (optional, default: True): return the "payload" property inside the workflows list response
 
 **Example response:**
 


### PR DESCRIPTION
* with_payload allows us to select if we want to return the "payload" property inside the list workflows response (defaults to True)
* do not return the payload property on list workflows call inside the UI

Signed-off-by: Maxime Caruchet <maxime.caruchet@corp.ovh.com>