### PR TITLE
feat(api): add workflow definition

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -170,6 +170,115 @@ HTTP/1.1 201 CREATED
 
 ```
 
+## **GET** `/api/list/workflows`
+
+Get the details of workflow.yml including next schedule run.
+
+**Example request:**
+
+```
+GET /api/list/workflows
+Host: example.com
+Accept: application/json
+```
+
+**Example response:**
+
+```
+HTTP/1.1 200 OK
+
+[
+  {
+    "fullname": "1.RANDOMS",
+    "name": "RANDOMS",
+    "next_run": "Wed, 10 Nov 2021 05:04:59 GMT",
+    "periodic": {
+      "crontab": "5 4 * * *"
+    },
+    "project": "1",
+    "tasks": [
+      {
+        "GROUP_RANDOMS": {
+          "tasks": [
+            "RANDOM",
+            "RANDOM"
+          ],
+          "type": "group"
+        }
+      },
+      "ADD"
+    ]
+  },
+  {
+    "fullname": "2.ETL",
+    "name": "ETL",
+    "next_run": "Wed, 01 Jun 2022 00:59:59 GMT",
+    "periodic": {
+      "schedule": "* * * * 6"
+    },
+    "project": "2",
+    "tasks": [
+      "EXTRACT",
+      "TRANSFORM",
+      "LOAD"
+    ]
+  },
+  {
+    "fullname": "44.RANDOMS",
+    "name": "RANDOMS",
+    "next_run": "Wed, 10 Nov 2021 09:04:59 GMT",
+    "periodic": {
+      "crontab": "5 8 * * *"
+    },
+    "project": "44",
+    "tasks": [
+      {
+        "GROUP_RANDOMS": {
+          "tasks": [
+            "RANDOM",
+            "RANDOM"
+          ],
+          "type": "group"
+        }
+      },
+      "ADD"
+    ]
+  },
+  {
+    "fullname": "example.ETL",
+    "name": "ETL",
+    "project": "example",
+    "tasks": [
+      "EXTRACT",
+      "TRANSFORM",
+      "LOAD"
+    ]
+  },
+  {
+    "fullname": "example.RANDOMS",
+    "name": "RANDOMS",
+    "next_run": "Tue, 09 Nov 2021 23:15:25 GMT",
+    "periodic": {
+      "interval": 90
+    },
+    "project": "example",
+    "tasks": [
+      {
+        "GROUP_RANDOMS": {
+          "tasks": [
+            "RANDOM",
+            "RANDOM"
+          ],
+          "type": "group"
+        }
+      },
+      "ADD"
+    ]
+  }
+]
+```
+
+
 ## **GET** `/api/ping`
 
 Health endpoint used to monitor Director API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Flask-json-schema==0.0.5
 Flask-Migrate==2.5.2
 Flask-HTTPAuth==4.1.0
 Werkzeug==1.0.1
+ItsDangerous==2.0.1
 
 # Misc
 gunicorn==20.0.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,3 +271,87 @@ def test_schema(client, no_worker):
     payload["payload"] = {"name": "foo", "price": 100}
     resp = client.post("/api/workflows", json=payload)
     assert resp.status_code == 201
+
+
+def test_get_definition(client, no_worker):
+    resp = client.get("/api/list/workflows")
+    assert resp.status_code == 200
+    assert resp.json == [
+        {
+            "fullname": "example.CELERY_ERROR_MULTIPLE_TASKS",
+            "name": "CELERY_ERROR_MULTIPLE_TASKS",
+            "project": "example",
+            "tasks": ["TASK_A", "TASK_CELERY_ERROR"],
+        },
+        {
+            "fullname": "example.CELERY_ERROR_ONE_TASK",
+            "name": "CELERY_ERROR_ONE_TASK",
+            "project": "example",
+            "tasks": ["TASK_CELERY_ERROR"],
+        },
+        {
+            "fullname": "example.ERROR",
+            "name": "ERROR",
+            "project": "example",
+            "tasks": ["TASK_ERROR"],
+        },
+        {
+            "fullname": "example.RETURN_EXCEPTION",
+            "name": "RETURN_EXCEPTION",
+            "project": "example",
+            "tasks": ["STR", "TASK_ERROR"],
+        },
+        {
+            "fullname": "example.RETURN_VALUES",
+            "name": "RETURN_VALUES",
+            "project": "example",
+            "tasks": ["STR", "INT", "LIST", "NONE", "DICT", "NESTED"],
+        },
+        {
+            "fullname": "example.SIMPLE_CHAIN",
+            "name": "SIMPLE_CHAIN",
+            "project": "example",
+            "tasks": ["TASK_A", "TASK_B", "TASK_C"],
+        },
+        {
+            "fullname": "example.SIMPLE_CHAIN_ERROR",
+            "name": "SIMPLE_CHAIN_ERROR",
+            "project": "example",
+            "tasks": ["TASK_A", "TASK_B", "TASK_ERROR"],
+        },
+        {
+            "fullname": "example.SIMPLE_GROUP",
+            "name": "SIMPLE_GROUP",
+            "project": "example",
+            "tasks": [
+                "TASK_A",
+                {"EXAMPLE_GROUP": {"tasks": ["TASK_B", "TASK_C"], "type": "group"}},
+            ],
+        },
+        {
+            "fullname": "example.SIMPLE_GROUP_ERROR",
+            "name": "SIMPLE_GROUP_ERROR",
+            "project": "example",
+            "tasks": [
+                "TASK_A",
+                {"EXAMPLE_GROUP": {"tasks": ["TASK_ERROR", "TASK_C"], "type": "group"}},
+            ],
+        },
+        {
+            "fullname": "example.WORKFLOW",
+            "name": "WORKFLOW",
+            "project": "example",
+            "tasks": ["TASK_EXAMPLE"],
+        },
+        {
+            "fullname": "schemas.SIMPLE_SCHEMA",
+            "name": "SIMPLE_SCHEMA",
+            "project": "schemas",
+            "schema": {
+                "properties": {"name": {"type": "string"}, "price": {"type": "number"}},
+                "required": ["name"],
+                "type": "object",
+            },
+            "tasks": ["TASK_EXAMPLE"],
+        },
+    ]


### PR DESCRIPTION
Fix issue #96. 
Add API route to get workflow definition (similar to `director workflow list`).
For each workflow with a periodic key, the next run date is added.

Signed-off-by: Paulin Charliquart <paulincharliquart@gmail.com>