### PR TITLE
Bugfix: ignore internal celery tasks in director_prerun

### DIFF
--- a/director/exceptions.py
+++ b/director/exceptions.py
@@ -16,3 +16,7 @@ class WorkflowSyntaxError(Exception):
 
 class UserNotFound(Exception):
     pass
+
+
+class TaskNotFound(Exception):
+    pass

--- a/director/models/tasks.py
+++ b/director/models/tasks.py
@@ -6,6 +6,7 @@ from sqlalchemy.types import PickleType
 from director.extensions import db
 from director.models import BaseModel, StatusType
 from director.models.utils import JSONBType
+from director.exceptions import TaskNotFound
 
 
 class Task(BaseModel):
@@ -29,6 +30,13 @@ class Task(BaseModel):
 
     def __repr__(self):
         return f"<Task {self.key}>"
+
+    @classmethod
+    def get_or_raise(cls, task_id):
+        task = cls.query.filter_by(id=task_id).first()
+        if not task:
+            raise TaskNotFound(f"Task {task_id} not found")
+        return task
 
     def to_dict(self):
         d = super().to_dict()


### PR DESCRIPTION
Celery chord callbacks work differently with redis vs postgres/rabbitmq result backends and require the use of polling with an internal celery task. This results in an unhandled exception being thrown in the the director_prerun handler.
ref: http://blog.untrod.com/2015/03/how-celery-chord-synchronization-works.html

- Added a check in `director_prerun` to ignore internal celery.* tasks
- Improved exception handling for tasks which are not found by creating
  a TaskNotFound exception and a Task#get_or_raise model function.

Signed-off-by: George Eddie <geddie@linius.com>