### PR TITLE
Add docker redis command to tests README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,7 @@ To test Celery Director in real conditions we decided to use an executing `worke
 $ (venv) git clone https://github.com/ovh/director && cd director
 $ (venv) python setup.py develop
 $ (venv) export DIRECTOR_HOME=`pwd`/tests/workflows/
+$ (venv) docker run -d -p 6379:6379 redis
 $ (venv) director celery worker -P solo -D
 ```
 


### PR DESCRIPTION
Adds an example redis docker run command to the test README

Signed-off-by: George Eddie [geddie@linius.com](mailto:geddie@linius.com)