### PR TITLE
Feature: distributed task processing and dynamic module loading

### DIFF
--- a/director/builder.py
+++ b/director/builder.py
@@ -1,4 +1,4 @@
-from celery import chain, group
+from celery import chain, group, subtask
 from celery.utils import uuid
 
 from director.exceptions import WorkflowSyntaxError
@@ -31,7 +31,8 @@ class WorkflowBuilder(object):
         task_id = uuid()
 
         # We create the Celery task specifying its UID
-        signature = cel.tasks.get(task_name).subtask(
+        signature = subtask(
+            task_name,
             kwargs={"workflow_id": self.workflow_id, "payload": self.workflow.payload},
             queue=self.queue,
             task_id=task_id,

--- a/director/settings.py
+++ b/director/settings.py
@@ -63,7 +63,13 @@ class Config(object):
                 "DIRECTOR_RESULT_BACKEND_URI", "redis://localhost:6379/1"
             ),
             "broker_transport_options": {"master_name": "director"},
+            "imports": ["director.tasks"],
         }
+
+        if any(env.list("DIRECTOR_CELERY_IMPORTS", [])):
+            self.CELERY_CONF['imports'] += env.list("DIRECTOR_CELERY_IMPORTS", [])
+        if any(env.list("DIRECTOR_CELERY_AUTO_DISCOVER", [])):
+            self.CELERY_AUTO_DISCOVER = env.list("DIRECTOR_CELERY_AUTO_DISCOVER", [])
 
         # Sentry configuration
         self.SENTRY_DSN = env.str("DIRECTOR_SENTRY_DSN", "")

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -36,6 +36,18 @@ tasks/
 
 The Python files in the `tasks` folder will contain your Celery tasks :
 
+Alternatively you can also use dynamic task loading on the workers by setting the
+`DIRECTOR_CELERY_IMPORTS` or `DIRECTOR_CELERY_AUTO_DISCOVER` environment variables
+to a list of modules. See the below celery documentation links for further details
+
+```shell
+# https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-imports
+$ export DIRECTOR_CELERY_IMPORTS="worker.local.tasks,worker.remote.tasks"
+# https://docs.celeryproject.org/en/stable/reference/celery.html#celery.Celery.autodiscover_tasks
+$ export DIRECTOR_CELERY_AUTO_DISCOVER="worker.local,worker.remote"
+```
+
+
 ```python
 from director import task
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -43,8 +44,9 @@ class DirectorResponse(Response):
         return _remove_keys(self.get_json(), self._KEYS_TO_REMOVE)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def app_module():
+    os.environ['DIRECTOR_CELERY_IMPORTS'] = 'tests.workflows.tasks'
     app = create_app(str(Path(__file__).parent.resolve() / "workflows"))
 
     with app.app_context():

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,3 +1,4 @@
+
 from director.extensions import DirectorSentry, cel
 
 
@@ -6,9 +7,9 @@ def test_sentry_enrich_data(app, create_builder):
 
     sentry = DirectorSentry()
     sentry.init_app(app)
-    tags = sentry.enrich_tags(
-        {"foo": "bar"}, wf.workflow_id, cel.tasks.get("TASK_EXAMPLE")
-    )
+    example_task = next(t for t in wf.canvas if t.name == "TASK_EXAMPLE")
+    tags = sentry.enrich_tags({"foo": "bar"}, wf.workflow_id, example_task)
+
     assert tags == {
         "foo": "bar",
         "celery_task_name": "TASK_EXAMPLE",


### PR DESCRIPTION
Added two new settings for defining dynamic task loading and
switched to using signatures when building workflows. This will allow
users to define custom task module locations and enable distributed task
processing (api/worker code+infra can be separated)

1) DIRECTOR_CELERY_IMPORTS: list of arbitrary files/modules to load
https://docs.celeryproject.org/en/stable/userguide/configuration.html#imports

2) DIRECTOR_CELERY_AUTO_DISCOVER: dynamic **/tasks module loading
https://docs.celeryproject.org/en/stable/reference/celery.html#celery.Celery.autodiscover_tasks
known bug (patched): https://github.com/celery/celery/pull/6424

refs:
https://docs.celeryproject.org/en/stable/reference/celery.html#module-celery
https://docs.celeryproject.org/en/stable/reference/celery.html#celery.signature

Signed-off-by: George Eddie geddie@linius.com