### PR TITLE
Updating .gitignore with *.egg-info/ and *.pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,15 @@ venv/
 
 # Build
 build/
-director.egg-info/
 dist/
+*.egg-info/
 
 # Celery
 celerybeat-schedule.bak
 celerybeat-schedule.dat
 celerybeat-schedule.dir
 celerybeat-schedule.db
+*.pid
 
 # IDE
 .vscode/


### PR DESCRIPTION
- use wildcard for *.egg-info 
- ignore wildcard celery *.pid files