### PR TITLE
Celery 5 upgrade and compliance

### DIFF
--- a/director/commands/celery.py
+++ b/director/commands/celery.py
@@ -18,9 +18,9 @@ def beat(dev_mode, beat_args):
     """Start the beat instance"""
     args = [
         "celery",
-        "beat",
         "-A",
         "director._auto:cel",
+        "beat",
     ]
     if dev_mode:
         args += [
@@ -38,9 +38,9 @@ def worker(dev_mode, worker_args):
     """Start a Celery worker instance"""
     args = [
         "celery",
-        "worker",
         "-A",
         "director._auto:cel",
+        "worker",
     ]
     if dev_mode:
         args += [
@@ -57,5 +57,6 @@ def worker(dev_mode, worker_args):
 def flower(ctx, flower_args):
     """Start the flower instance"""
     broker = ctx.app.config["CELERY_CONF"]["broker_url"]
-    args = ["flower", "-b", broker] + list(flower_args)
+    args = ["celery", "-b", broker, "flower"]
+    args += list(flower_args)
     os.execvp(args[0], args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Celery Packages
-celery==4.4.7
-flower==0.9.3
-kombu==4.6.11
+celery==5.1.2
+flower==1.0.0
+kombu==5.1.0
 
 # Databases
 psycopg2-binary==2.8.4


### PR DESCRIPTION
Upgrading to celery 5
- [Upgrading from Celery 4.x](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#upgrading-from-celery-4-x)

Change Notes
- [python 3.6 is now end of life](https://docs.celeryproject.org/en/stable/changelog.html#b3)
- [Confusion regarding flower 1.0.0 supports Celery 5 (it does)](https://github.com/mher/flower/issues/1144#issuecomment-1064282547)

Package Upgrades
- celery==4.4.7 -> [celery==5.1.2](https://docs.celeryproject.org/en/master/history/changelog-5.1.html#id1) (latest supported version for python 3.6)
- flower==0.9.3 -> [flower==1.0.0](https://pypi.org/project/flower/1.0.0/) (required for celery 5)
- kombu==4.6.11 -> [kombu==5.1.0](https://docs.celeryproject.org/projects/kombu/en/stable/changelog.html#version-5-1-0) (required for celery 5)

Signed-off-by: George Eddie geddie@linius.com