### PR TITLE
Updated requirements.txt and psycopg2-binary version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flower==1.0.0
 kombu==5.2.4
 
 # Databases
-psycopg2-binary==2.8.4
+psycopg2-binary==2.9.3
 SQLAlchemy==1.3.11
 sqlalchemy-utils==0.35.0
 mysql-connector-python==8.0.21


### PR DESCRIPTION
Purpose was to test installation on mac m1's which have new binaries
