### PR TITLE
feat(ui) add docs link in navbar

### DIFF
--- a/director/static/script.js
+++ b/director/static/script.js
@@ -235,6 +235,10 @@ new Vue({
     selectedStatus: [],
     status: ['success', 'error', 'progress', 'pending'],
     selectedWorkflowName: "All",
+    sidebar: false,
+    menuItems: [
+      {title: "Docs", link: "https://ovh.github.io/celery-director/"}
+    ]
   }),
   mounted() {
     const theme = localStorage.getItem("dark_theme");

--- a/director/templates/index.html
+++ b/director/templates/index.html
@@ -27,13 +27,44 @@
     <div id="app" v-cloak>
       <v-app id="inspire">
         <v-app-bar app clipped-right color="director" dark>
+          <v-app-bar-nav-icon @click.stop="sidebar = !sidebar" class="hidden-md-and-up"></v-app-bar-nav-icon>
           <v-toolbar-title @click="router.push({name: 'home'}).catch(()=>{})" class="pointer">Celery Director</v-toolbar-title>
           <v-spacer></v-spacer>
+          <v-toolbar-items class="hidden-sm-and-down mr-3">
+            <v-list-item
+              v-for="item in menuItems"
+              :key="item.title"
+              :href="item.link"
+              target="_blank"
+              >
+              <v-list-item-content>
+                <v-list-item-title>{{ item.title }}</v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+          </v-toolbar-items>
           <v-switch v-model="$vuetify.theme.dark" label="Dark Mode" dense hide-details=false class="mr-5"></v-switch>
           <a :href="repoLink" class="text-decoration-none" target="_blank">
             <v-icon large>mdi-github</v-icon>
           </a>
         </v-app-bar>
+        <v-navigation-drawer v-model="sidebar"
+          absolute
+          temporary
+          >
+          <v-list>
+            <v-list-item
+              v-for="item in menuItems"
+              :key="item.title"
+              :href="item.link"
+              target="_blank"
+              >
+              <v-list-item-content>
+                <v-list-item-title>{{ item.title }}</v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-navigation-drawer>
         <v-main>
           <v-container v-if="!$route.params.id">
             <v-row>


### PR DESCRIPTION
Add link to Celery director documentation in the navbar

full screen:

![image](https://user-images.githubusercontent.com/64043642/167730820-dd8e18f8-713c-4caf-b752-3b8e6300635e.png)


small screen

![image](https://user-images.githubusercontent.com/64043642/167731195-1405452e-967d-4899-be40-bcc790bf4fd1.png)


![image](https://user-images.githubusercontent.com/64043642/167731028-2f6e9bce-2ff7-49bf-a6c4-80751b453ad3.png)
