### PR TITLE
feat: Add per-task queue routing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -336,6 +336,16 @@ def test_list_definitions(client, no_worker):
             ],
         },
         {
+            "fullname": "example.TASK_ROUTING",
+            "name": "TASK_ROUTING",
+            "project": "example",
+            "queue": {"customs": {"TASK_B": "q2"}, "default": "q1"},
+            "tasks": [
+                "TASK_A",
+                {"EXAMPLE_GROUP": {"tasks": ["TASK_B", "TASK_C"], "type": "group"}},
+            ],
+        },
+        {
             "fullname": "example.WORKFLOW",
             "name": "WORKFLOW",
             "project": "example",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -124,3 +124,25 @@ def test_build_grouped_tasks(app, create_builder):
         "result": None,
         "status": "pending",
     }
+
+
+def test_build_tasks_with_routing(create_builder):
+    data, builder = create_builder("example", "TASK_ROUTING", {"foo": "bar"})
+
+    assert len(builder.canvas) == 4
+    assert builder.canvas[0].task == "director.tasks.workflows.start"
+    assert builder.canvas[-1].task == "director.tasks.workflows.end"
+
+    # Checl the task queues in canvas
+    assert builder.canvas[1].task == "TASK_A"
+    assert builder.canvas[1].options["queue"] == "q1"
+
+    assert builder.canvas[2].task == "celery.group"
+    group_tasks = builder.canvas[2].tasks
+    assert len(group_tasks) == 2
+
+    assert group_tasks[0].task == "TASK_B"
+    assert group_tasks[1].task == "TASK_C"
+
+    assert group_tasks[0].options["queue"] == "q2"
+    assert group_tasks[1].options["queue"] == "q1"

--- a/tests/workflows/workflows.yml
+++ b/tests/workflows/workflows.yml
@@ -64,3 +64,16 @@ example.RETURN_EXCEPTION:
   tasks:
     - STR
     - TASK_ERROR
+
+example.TASK_ROUTING:
+  tasks:
+    - TASK_A
+    - EXAMPLE_GROUP:
+        type: group
+        tasks:
+          - TASK_B
+          - TASK_C
+  queue:
+    default: q1
+    customs:
+      TASK_B: q2


### PR DESCRIPTION
Add the possibility to route task individually in a workflow.

```yaml
example.ETL:
  tasks:
    - [EXTRACT, queue1]
    - [TRANSFORM, queue2]
    - LOAD
```

In the following case, the task-level queue overrides the workflow-level queue for the task where a queue is defined.
```yaml
example.ETL:
  tasks:
    - EXTRACT
    - [TRANSFORM, queue2] # task-level
    - LOAD
  queue: queue1 # workflow-level
```