### PR TITLE
fix: use the state to store the definitions

### DIFF
--- a/director/static/script.js
+++ b/director/static/script.js
@@ -29,18 +29,19 @@ const router = new VueRouter({
       path: "/",
     },
     {
-      name: "worfklow",
-      path: "/:id",
+      name: 'definitions',
+      path: '/definitions'
     },
     {
-      name: "definitions",
-      path: "/definitions",
-    },
-  ],
+      name: 'worfklow',
+      path: '/:id'
+    }
+  ]
 });
 
 const store = new Vuex.Store({
   state: {
+    definitions: [],
     workflows: [],
     workflowNames: [],
     network: null,
@@ -55,6 +56,14 @@ const store = new Vuex.Store({
         commit("updateWorkflows", response.data);
         commit("changeLoadingState", false);
       });
+    },
+    listDefinitions({
+      commit
+    }) {
+      axios.get(API_URL + "/definitions").then((response) => {
+        commit('updateDefinitions', response.data)
+        commit('changeLoadingState', false)
+      })
     },
     getWorkflow({ commit }, workflow_id) {
       axios.get(API_URL + "/workflows/" + workflow_id).then((response) => {
@@ -81,6 +90,9 @@ const store = new Vuex.Store({
       state.workflowNames = ["All"].concat([
         ...new Set(workflows.map((item) => item.fullname)),
       ]);
+    },
+    updateDefinitions(state, definitions) {
+      state.definitions = definitions
     },
     updateSelectedWorkflow(state, workflow) {
       state.taskIndex = null;
@@ -223,6 +235,7 @@ new Vue({
       ];
     },
     ...Vuex.mapState([
+      "definitions",
       "workflows",
       "workflowNames",
       "selectedWorkflow",
@@ -246,7 +259,6 @@ new Vue({
     multiLine: true,
     snackbar: false,
     dialog: false,
-    workflowsDefinitionsList: [],
     postWorkflowResponse: "",
     dialogState: "",
     statusAlert: { success: "success", error: "error", pending: "pending" },
@@ -319,12 +331,6 @@ new Vue({
       }
       return "";
     },
-    getDefinitions: function () {
-      urlDefinitions = API_URL + "/definitions";
-      axios.get(urlDefinitions).then((response) => {
-        this.workflowsDefinitionsList = response.data;
-      });
-    },
 
     runButton: function (item) {
       (this.postWorkflowResponse = ""),
@@ -384,13 +390,16 @@ new Vue({
   },
   created() {
     this.isHome = true;
-    this.getDefinitions();
-
-    this.$store.dispatch("listWorkflows");
+    this.$store.dispatch('listDefinitions');
+    this.$store.dispatch('listWorkflows');
 
     this.interval = setInterval(() => {
       this.$store.dispatch("listWorkflows");
     }, REFRESH_INTERVAL);
+
+    if (this.$route.name == "definitions") {
+        this.isHome = false;
+    }
 
     let workflowID = this.$route.params.id;
     if (workflowID) {

--- a/director/templates/index.html
+++ b/director/templates/index.html
@@ -97,7 +97,7 @@
               <router-link to="/definitions">
                 <button
                   style="margin-left: 1em"
-                  @click="isHome = false, getDefinitions()"
+                  @click="isHome = false"
                 >
                   <v-list-item>
                     <v-list-item-icon>
@@ -564,7 +564,7 @@
                         </thead>
                         <tbody>
                           <tr
-                            v-for="item in workflowsDefinitionsList"
+                            v-for="item in definitions"
                             :key="item.name"
                           >
                             <td>{{ item.project }}</td>


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@ovhcloud.com>

This PR removes a 500 HTTP error when refreshing (F5) the list of definitions.

![image](https://user-images.githubusercontent.com/1552526/180416456-856aa8f0-8ab6-4108-920b-4c999598c850.png)




