### PR TITLE
chore: update the default reviewers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default reviewers
-*       @ncrocfer @anthonyolea @ziirish @maximecaruchet @ministicraft @ismailrei
+*       @ncrocfer @anthonyolea @maximecaruchet @ministicraft @ismailrei @BenoitBarbereau @cerealito


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@ovhcloud.com>