### PR TITLE
feat: add description field to workflows

### DIFF
--- a/director/commands/workflows.py
+++ b/director/commands/workflows.py
@@ -106,8 +106,9 @@ def show_workflow(ctx, name):
 @workflow.command(name="run")
 @click.argument("fullname")
 @click.argument("payload", required=False, default="{}")
+@click.option("--comment", help="A comment for the workflow instance.")
 @pass_ctx
-def run_workflow(ctx, fullname, payload):
+def run_workflow(ctx, fullname, payload, comment):
     """Execute a workflow"""
     try:
         wf = cel_workflows.get_by_name(fullname)
@@ -133,7 +134,7 @@ def run_workflow(ctx, fullname, payload):
 
     # Create the workflow object
     project, name = fullname.split(".")
-    obj = Workflow(project=project, name=name, payload=payload)
+    obj = Workflow(project=project, name=name, payload=payload, comment=comment)
     obj.save()
 
     # Build the canvas and execute it

--- a/director/migrations/versions/9d563aaa548b_add_workflow_comment.py
+++ b/director/migrations/versions/9d563aaa548b_add_workflow_comment.py
@@ -1,0 +1,27 @@
+"""Add workflow comment
+
+Revision ID: 9d563aaa548b
+Revises: 9817ccf13cb5
+Create Date: 2022-07-26 19:45:40.946254
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9d563aaa548b"
+down_revision = "9817ccf13cb5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "workflows",
+        sa.Column("comment", sa.String(255), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("workflows", "comment")

--- a/director/models/workflows.py
+++ b/director/models/workflows.py
@@ -11,6 +11,7 @@ class Workflow(BaseModel):
     status = db.Column(db.Enum(StatusType), default=StatusType.pending, nullable=False)
     payload = db.Column(JSONBType, default={})
     periodic = db.Column(db.Boolean, default=False)
+    comment = db.Column(db.String(255))
 
     def __str__(self):
         return f"{self.project}.{self.name}"
@@ -29,6 +30,8 @@ class Workflow(BaseModel):
                 "periodic": self.periodic,
             }
         )
+        if self.comment is not None:
+            d["comment"] = self.comment
         if with_payload:
             d["payload"] = self.payload
         return d

--- a/director/static/script.js
+++ b/director/static/script.js
@@ -228,7 +228,6 @@ new Vue({
           text: "Name",
           align: "left",
           value: "fullname",
-          width: "56%",
           filter: (value) => {
             if (
               !this.selectedWorkflowName ||
@@ -239,10 +238,18 @@ new Vue({
           },
         },
         {
+          text: "Comment",
+          align: "left",
+          value: "comment",
+          align: store.state.workflows.filter(
+            workflow => workflow.comment != null).length === 0 
+            && " d-none"
+        },
+        {
           text: "Date",
           align: "left",
           value: "created",
-          width: "30%",
+          width: "25%",
         },
       ];
     },
@@ -277,6 +284,7 @@ new Vue({
     statusAlert: { success: "success", error: "error", pending: "pending", canceled: "canceled" },
     isWorkflowRun: false,
     payloadValue: "",
+    commentValue: "",
     selectedRunningWorkflow: null,
     postWorkflowErrorJSON: "",
     // workflow (home)
@@ -320,6 +328,12 @@ new Vue({
       }[status];
       return color;
     },
+
+    isCommentFieldActive: function () {
+      return this.$store.state.workflows.filter(
+        workflow => workflow.comment != null).length > 0 
+    },
+
     selectRow: function (item) {
       // Catch to avoid redundant navigation to current location error
       this.$router
@@ -355,6 +369,7 @@ new Vue({
       (this.postWorkflowResponse = ""),
         (this.postWorkflowErrorJSON = ""),
         (this.payloadValue = ""),
+        (this.commentValue = ""),
         (this.dialog = true),
         (this.snackbar = false),
         (this.selectedRunningWorkflow = item);
@@ -382,6 +397,8 @@ new Vue({
         name: this.selectedRunningWorkflow.name,
         payload: payloadValueTrim ? payloadValueParsed : {},
       };
+
+      if (this.commentValue.length > 0) data.comment = this.commentValue
 
       const headers = { "content-type": "application/json" };
       const urlWorkflow = API_URL + "/workflows";

--- a/director/templates/index.html
+++ b/director/templates/index.html
@@ -166,6 +166,7 @@
                             ></v-avatar>
                           </td>
                           <td>{{ item.fullname }}</td>
+                          <td v-if="isCommentFieldActive()" >{{ item.comment }}</td>
                           <td>
                             <v-ship>{{ item.created | formatDate }}</v-ship>
                           </td>
@@ -275,6 +276,9 @@
                         >{{ selectedWorkflow.status }}</v-chip
                       >
                     </v-list-item-title>
+                    <v-list-item-subtitle v-if="isCommentFieldActive()" class="mt-2">
+                      {{ selectedWorkflow.comment }}
+                    </v-list-item-subtitle>
                     <v-list-item-subtitle class="mt-2">
                       <u>Tasks :</u> Total
                       <strong>{{ selectedWorkflow.tasks.length }}</strong> /
@@ -666,7 +670,7 @@
         <v-dialog v-model="dialog" persistent max-width="600px">
           <v-card>
             <v-card-title>
-              <span class="text-h5">Payload Information</span>
+              <span class="text-h5">Workflow data</span>
             </v-card-title>
             <v-card-text>
               <v-container>
@@ -677,13 +681,28 @@
                 </p>
                 <v-row>
                   <v-col cols="12" sm="12" md="12">
+                    <v-text-field
+                    v-model="commentValue"
+                    label="Workflow comment"
+                    filled
+                    hint="optional"
+                    persistent-hint
+                    ></v-text-field>
+                  </v-col>
+                </v-row>
+                <v-row>
+                  <v-col cols="12" sm="12" md="12">
                     <v-textarea
                       class="monospacedPayload"
                       v-model="payloadValue"
-                      label="(optional) Fill the payload here :"
+                      label="Fill the payload here :"
+                      hint="optional"
+                      persistent-hint
+                      placeholder='{&#10;&#9;"key": "value",&#10;&#9;...&#10;}'
                       type="json"
                       required
                       auto-grow
+                      filled
                       font-family="Monospace"
                     >
                     </v-textarea>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,21 @@ def test_post_workflow_with_payload(client, no_worker):
     }
 
 
+def test_post_workflow_with_comment(client, no_worker):
+    payload = {**DEFAULT_PAYLOAD, "comment": "This is an example workflow."}
+    resp = client.post("/api/workflows", json=payload)
+    assert resp.status_code == 201
+    assert resp.json == {
+        "fullname": "example.WORKFLOW",
+        "name": "WORKFLOW",
+        "payload": {},
+        "comment": "This is an example workflow.",
+        "periodic": False,
+        "project": "example",
+        "status": "pending",
+    }
+
+
 def test_post_workflow_required_props(client):
     resp = client.post("/api/workflows", json={})
     assert resp.status_code == 400
@@ -79,7 +94,11 @@ def test_relaunch_not_existing_workflow(client):
 
 
 def test_relaunch_workflow(client, no_worker):
-    payload = {**DEFAULT_PAYLOAD, "payload": {"nested": {"foo": "bar"}}}
+    payload = {
+        **DEFAULT_PAYLOAD,
+        "payload": {"nested": {"foo": "bar"}},
+        "comment": "This is an example workflow.",
+    }
     resp = client.post("/api/workflows", json=payload)
     with patch("tests.conftest.DirectorResponse._KEYS_TO_REMOVE", new=[]):
         workflow_id = resp.json["id"]
@@ -91,6 +110,7 @@ def test_relaunch_workflow(client, no_worker):
         "fullname": "example.WORKFLOW",
         "name": "WORKFLOW",
         "payload": {"nested": {"foo": "bar"}},
+        "comment": "This is an example workflow.",
         "periodic": False,
         "project": "example",
         "status": "pending",


### PR DESCRIPTION
In order to improve the monitoring experience on the UI I added a description field to the workflows table.
This way it is possible to add specific information to each workflow instance, and distinguish between the different runs.

Of course, the description is optional. 
You can run a workflow with description in three ways :

**1. Using CLI**
```bash
director workflow run product.ORDER '{"user": 1234, "product": 1000}' --description "short description here"
```
**2. Using API**
```bash
curl --header "Content-Type: application/json" \
  --request POST \
  --data '{"project": "product", "name": "ORDER", \
    "payload": {"user": 1234, "product": 1000}, \
    "description": "short description here"}' \
  http://localhost:8000/api/workflows
```

**3. Using UI, on the "Definition" page**

![desc-ui](https://user-images.githubusercontent.com/26455805/183691080-e85e1203-2ab4-4d42-b470-d078d1cad50a.png)

After running at least one workflow with a description you will be able to see the description in the web UI

![desc-wf-list](https://user-images.githubusercontent.com/26455805/183692554-603942fb-8541-4217-9538-d3aeeddf2398.png)
![desc-details](https://user-images.githubusercontent.com/26455805/183692581-fff6ebae-a509-4d8b-ba11-2e2840848179.png)

---

Two remarks:
- In order to add the description field, I had to add a migration in the middle of the revisions history, I am not sure that it is OK when upgrading an existing Celery-Director instance.
- The UI part of the commit might not be perfect as I am not a Vue.js specialist.

Thanks for your reading