### PR TITLE
chore: limit importlib-metadata package to avoid Py3.7 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ pyyaml==5.4.1
 terminaltables==3.1.0
 pluginbase==1.0.0
 sentry-sdk==0.16.3
+importlib-metadata==4.13.0


### PR DESCRIPTION
This PR fixes a bug when using Celery with Python 3.7 (https://github.com/celery/celery/issues/7783).