### PR TITLE
fix: upgrade sql requirements to support the online mode

### DIFF
--- a/director/migrations/versions/2ac615d6850b_force_varchar_255.py
+++ b/director/migrations/versions/2ac615d6850b_force_varchar_255.py
@@ -8,8 +8,6 @@ Create Date: 2020-10-09 17:35:12.402690
 from alembic import op
 import sqlalchemy as sa
 
-from director.extensions import db
-
 
 # revision identifiers, used by Alembic.
 revision = "2ac615d6850b"
@@ -17,15 +15,12 @@ down_revision = "063ff371f2da"
 branch_labels = None
 depends_on = None
 
-# Store the list of tables
-tables = {t[0]: t[1] for t in db.metadata.tables.items()}
-
 
 def upgrade():
     """
     This migration is only useful for an existing Celery Director instance.
     """
-    with op.batch_alter_table("tasks", copy_from=tables["tasks"]) as batch_op:
+    with op.batch_alter_table("tasks") as batch_op:
         batch_op.alter_column(
             "key",
             existing_type=sa.VARCHAR(),
@@ -33,7 +28,7 @@ def upgrade():
             existing_nullable=False,
         )
 
-    with op.batch_alter_table("users", copy_from=tables["users"]) as batch_op:
+    with op.batch_alter_table("users") as batch_op:
         batch_op.alter_column(
             "password",
             existing_type=sa.VARCHAR(),
@@ -47,7 +42,7 @@ def upgrade():
             existing_nullable=False,
         )
 
-    with op.batch_alter_table("workflows", copy_from=tables["workflows"]) as batch_op:
+    with op.batch_alter_table("workflows") as batch_op:
         batch_op.alter_column(
             "name",
             existing_type=sa.VARCHAR(),
@@ -63,7 +58,7 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table("workflows", copy_from=tables["workflows"]) as batch_op:
+    with op.batch_alter_table("workflows") as batch_op:
         batch_op.alter_column(
             "project",
             existing_type=sa.String(length=255),
@@ -77,7 +72,7 @@ def downgrade():
             existing_nullable=False,
         )
 
-    with op.batch_alter_table("users", copy_from=tables["users"]) as batch_op:
+    with op.batch_alter_table("users") as batch_op:
         batch_op.alter_column(
             "username",
             existing_type=sa.String(length=255),
@@ -91,7 +86,7 @@ def downgrade():
             existing_nullable=False,
         )
 
-    with op.batch_alter_table("tasks", copy_from=tables["tasks"]) as batch_op:
+    with op.batch_alter_table("tasks") as batch_op:
         batch_op.alter_column(
             "key",
             existing_type=sa.String(length=255),

--- a/director/migrations/versions/46e4acde004e_add_cascade_in_task_model.py
+++ b/director/migrations/versions/46e4acde004e_add_cascade_in_task_model.py
@@ -6,7 +6,6 @@ Create Date: 2021-07-16 11:54:27.946028
 
 """
 from alembic import op
-from director.extensions import db
 
 
 # revision identifiers, used by Alembic.
@@ -15,8 +14,6 @@ down_revision = "2ac615d6850b"
 branch_labels = None
 depends_on = None
 
-tables = db.metadata.tables
-
 
 def upgrade():
     bind = op.get_bind()
@@ -24,7 +21,7 @@ def upgrade():
         # SQLite does not support to alter constraints on existing tables.
         # Batch mode is used to copy data to a temporary table meanwhile creating a brand new
         # table with the required constraint.
-        with op.batch_alter_table("tasks", copy_from=tables["tasks"]) as batch_op:
+        with op.batch_alter_table("tasks") as batch_op:
             batch_op.drop_constraint(
                 op.f("fk_tasks_workflow_id_workflows"), type_="foreignkey"
             )
@@ -53,7 +50,7 @@ def upgrade():
 def downgrade():
     bind = op.get_bind()
     if bind.engine.name == "sqlite":
-        with op.batch_alter_table("tasks", copy_from=tables["tasks"]) as batch_op:
+        with op.batch_alter_table("tasks") as batch_op:
             batch_op.drop_constraint(
                 op.f("fk_tasks_workflow_id_workflows"), type_="foreignkey"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ flower==1.2.0
 kombu==5.2.4
 
 # Databases
-psycopg2-binary==2.9.3
-SQLAlchemy==1.3.11
-sqlalchemy-utils==0.35.0
-mysql-connector-python==8.0.21
+psycopg2-binary==2.9.5
+SQLAlchemy==1.4.44
+sqlalchemy-utils==0.38.3
+mysql-connector-python==8.0.31
 redis==4.2.2
-alembic==1.3.2
+alembic==1.8.1
 
 # Flask
 Flask==2.1.1


### PR DESCRIPTION
This PR switches to online mode in order to fix https://github.com/ovh/celery-director/issues/164

After merging it we'll be able to review & merge #170 and #162 (these PRs introduce new migrations).

POC:

```
$ cat director/migrations/versions/ea91724fbbb9_add_foo.py
"""add foo

Revision ID: ea91724fbbb9
Revises: 46e4acde004e
Create Date: 2022-11-22 16:38:13.759083

"""
from alembic import op
import sqlalchemy as sa


# revision identifiers, used by Alembic.
revision = 'ea91724fbbb9'
down_revision = '46e4acde004e'
branch_labels = None
depends_on = None


def upgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    op.add_column('workflows', sa.Column('foo', sa.String(length=255), nullable=False))
    # ### end Alembic commands ###


def downgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    op.drop_column('workflows', 'foo')
    # ### end Alembic commands ###

$ director db upgrade
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 30d6f6636351, Initial migration
INFO  [alembic.runtime.migration] Running upgrade 30d6f6636351 -> 05cf96d6fcae, Add task result
INFO  [alembic.runtime.migration] Running upgrade 05cf96d6fcae -> 3f8466b16023, Add users table
INFO  [alembic.runtime.migration] Running upgrade 3f8466b16023 -> 063ff371f2da, Add index on workflow_id in task table
INFO  [alembic.runtime.migration] Running upgrade 063ff371f2da -> 2ac615d6850b, Force varchar 255
INFO  [alembic.runtime.migration] Running upgrade 2ac615d6850b -> 46e4acde004e, Add cascade in task model for workflow deletion
INFO  [alembic.runtime.migration] Running upgrade 46e4acde004e -> ea91724fbbb9, add foo

$ director db upgrade 46e4acde004e:ea91724fbbb9 --sql
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Generating static SQL
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 46e4acde004e -> ea91724fbbb9, add foo
-- Running upgrade 46e4acde004e -> ea91724fbbb9

ALTER TABLE workflows ADD COLUMN foo VARCHAR(255) NOT NULL;

UPDATE alembic_version SET version_num='ea91724fbbb9' WHERE alembic_version.version_num = '46e4acde004e';
```

Tested with SQLite & PostgreSQL.

