### PR TITLE
chore: update the list of codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default reviewers
-*       @ncrocfer @anthonyolea @maximecaruchet @ministicraft @ismailrei @BenoitBarbereau @cerealito
+*       @ncrocfer @maximecaruchet @ministicraft @ismailrei @BenoitBarbereau @cerealito @zozoh94


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@ovhcloud.com>