### PR TITLE
chore: bump the environs package

### DIFF
--- a/director/settings.py
+++ b/director/settings.py
@@ -21,7 +21,9 @@ class Config(object):
     def __init__(self, home_path=None, config_path=None):
         if not home_path or not Path(home_path).resolve().exists():
             raise ValueError("environment variable DIRECTOR_HOME is not set correctly")
-        self.DIRECTOR_HOME = env_path = str(home_path)
+
+        env_path = Path(home_path) / ".env"
+        self.DIRECTOR_HOME = str(home_path)
 
         if config_path:
             if not Path(config_path).resolve().exists():

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ Werkzeug==2.2.3
 
 # Misc
 gunicorn==20.0.4
-environs==6.1.0
+environs==9.5.0
 pyyaml==5.4.1
 terminaltables==3.1.0
 pluginbase==1.0.0


### PR DESCRIPTION
This PR bumps the `environs` package so it removes the warning messages in pytest:

**Before**

```
$ tests/test_api.py::test_pong -v
[...]
tests/test_api.py::test_pong
  /Users/ncrocfer/Dev/deploy/celery-director/venv/lib/python3.8/site-packages/marshmallow/fields.py:949: RemovedInMarshmallow4Warning: The 'missing' argument to fields is deprecated. Use 'load_default' instead.
    super().__init__(**kwargs)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================== 1 passed, 41 warnings in 0.17s ========================================================================
```

**After**
```

$ pytest tests/test_api.py::test_pong -v
tests/test_api.py .                                                                                                                                                      [100%]

============================================================================== 1 passed in 0.23s ===============================================================================
```

The v8.0.0 introduces a [breaking change](https://github.com/sloria/environs/blob/master/CHANGELOG.md#800-2020-05-27), so we have to have to add the `.env` file in our `env_path` variable during the Flask Config initialization.