### PR TITLE
Add support for Python 3.10 & 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: ['3.7', '3.8', '3.9']
+          python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
           database-type: ["sqlite", "postgres"]
     services:
       redis:

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: System :: Monitoring",
     ],
     python_requires="~=3.7",

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,9 +5,9 @@ To test Celery Director in real conditions we decided to use an executing `worke
 
 ```
 $ (venv) git clone https://github.com/ovh/celery-director && cd celery-director
-$ (venv) python setup.py develop
+$ (venv) pip install -e "."
 $ (venv) export DIRECTOR_HOME=`pwd`/tests/workflows/
-$ (venv) director celery worker -P solo -D
+$ (venv) director celery worker --concurrency=1
 ```
 
 Configuration (database, redis...) can be customized in the `$DIRECTOR_HOME/.env` file.
@@ -15,6 +15,6 @@ Configuration (database, redis...) can be customized in the `$DIRECTOR_HOME/.env
 You can then launch the tests in another terminal :
 
 ```
-$ pip install pytest==5.3.5
+$ pip install ".[ci]"
 $ pytest tests/ -v
 ```

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -305,7 +305,7 @@ def test_cancel_workflow(app):
         builder.cancel()
 
         # DB rows status updated
-        time.sleep(0.5)
+        time.sleep(5)
 
         workflow = Workflow.query.filter_by(id=workflow.id).first()
 


### PR DESCRIPTION
This PR adds the support for **Python 3.10 & 3.11**.

I also increment the sleep duration between the `test_cancel_workflow ` and `test_return_values ` tests to let the first one finish its work and not impact the second one (before that the 2nd test fails from time to time). 