### PR TITLE
bump: pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ Werkzeug==2.3.3
 # Misc
 gunicorn==20.0.4
 environs==9.5.0
-pyyaml==5.4.1
+pyyaml==6.0.1
 terminaltables==3.1.0
 pluginbase==1.0.0
 sentry-sdk==1.14.0


### PR DESCRIPTION
Related to the `  AttributeError: cython_sources` error (see https://github.com/yaml/pyyaml/issues/724).

